### PR TITLE
fuzzy matching in menu search

### DIFF
--- a/src/haven/Fuzzy.java
+++ b/src/haven/Fuzzy.java
@@ -1,0 +1,83 @@
+package haven;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import haven.MenuSearch.Result;
+
+
+public class Fuzzy {
+
+    /**
+     * Calculates the Jaccard similarity between two strings based on character sets.
+     * 
+     * @param str1 The first string.
+     * @param str2 The second string.
+     * @return A double value representing the Jaccard similarity.
+     */
+    public static double jaccardSimilarity(String str1, String str2) {
+        Set<Character> set1 = new HashSet<>();
+        Set<Character> set2 = new HashSet<>();
+
+        for (char ch : str1.toCharArray()) {
+            set1.add(ch);
+        }
+        for (char ch : str2.toCharArray()) {
+            set2.add(ch);
+        }
+
+        Set<Character> intersection = new HashSet<>(set1);
+        intersection.retainAll(set2);
+
+        Set<Character> union = new HashSet<>(set1);
+        union.addAll(set2);
+
+        return union.isEmpty() ? 0 : (double) intersection.size() / union.size();
+    }
+
+    /**
+     * Performs sequential fuzzy substring matching.
+     * Checks if all characters of the needle appear in the haystack in the same order.
+     * 
+     * @param haystack The string to search within.
+     * @param needle The substring to search for.
+     * @return True if the haystack contains the needle in a fuzzy sequential manner, false otherwise.
+     */
+    public static boolean fuzzyContains(String haystack, String needle) {
+        int hayIndex = 0;
+        for (char ch : needle.toCharArray()) {
+            hayIndex = haystack.indexOf(ch, hayIndex);
+            if (hayIndex == -1) {
+                return false;
+            }
+            hayIndex++; // Move past the found character for the next search
+        }
+        return true;
+    }
+
+    /**
+     * Filters a list of results based on fuzzy matching with a given needle string.
+     * Sorts the results by Jaccard similarity.
+     * 
+     * @param needle The string to search for in each result.
+     * @param results The list of results to filter and sort.
+     * @return A list of results that match the needle, sorted by Jaccard similarity.
+     */
+    public static List<Result> fuzzyFilterAndSort(String needle, List<Result> results) {
+        List<Result> found = new ArrayList<>();
+        String lowerNeedle = needle.toLowerCase();
+
+        for (Result res : results) {
+            String haystack = res.btn.name().toLowerCase();
+            if (fuzzyContains(haystack, lowerNeedle)) {
+                found.add(res);
+            }
+        }
+
+        // Sort using Jaccard similarity (common letters regardless of relative positions)
+        found.sort(Comparator.comparingDouble(res -> -jaccardSimilarity(lowerNeedle, res.btn.name().toLowerCase())));
+        return found;
+    }
+}

--- a/src/haven/Gob.java
+++ b/src/haven/Gob.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Future;
 import java.util.function.*;
 import java.util.stream.Collectors;
 
+import haven.Fuzzy;
 import haven.automated.mapper.MappingClient;
 import haven.render.*;
 import haven.render.gl.GLObject;
@@ -1752,7 +1753,7 @@ public class Gob implements RenderTree.Node, Sprite.Owner, Skeleton.ModOwner, Eq
 		if (getres() == null) return;
 		String resourceName = getres().basename().toLowerCase().replace("stockpile", "");
 		String searchKeyword = ObjectSearchWindow.objectSearchString.toLowerCase();
-		boolean result = resourceName.contains(searchKeyword) && searchKeyword.length() > 1;
+		boolean result = searchKeyword.length() > 1 && Fuzzy.fuzzyContains(resourceName, searchKeyword);
 		String barterStandOverlays = null;
 		if (resourceName.contains("barter")) {
 			try {
@@ -1776,7 +1777,7 @@ public class Gob implements RenderTree.Node, Sprite.Owner, Skeleton.ModOwner, Eq
 			}
 		}
 		if (barterStandOverlays != null) {
-			if (searchKeyword.startsWith("@") && searchKeyword.length() > 2 && barterStandOverlays.contains(searchKeyword.replaceAll("@", ""))) {
+			if (searchKeyword.startsWith("@") && Fuzzy.fuzzyContains(barterStandOverlays, searchKeyword.replaceAll("@", "")) && searchKeyword.length() > 2) {
 				result = true;
 			}
 		}

--- a/src/haven/MenuSearch.java
+++ b/src/haven/MenuSearch.java
@@ -80,49 +80,8 @@ public class MenuSearch extends Window {
 	setroot(null);
     }
 
-    private double jaccardSimilarity(String str1, String str2) {
-	Set<Character> set1 = new HashSet<>();
-	Set<Character> set2 = new HashSet<>();
-
-	for (char ch : str1.toCharArray()) {
-	    set1.add(ch);
-	}
-	for (char ch : str2.toCharArray()) {
-	    set2.add(ch);
-	}
-
-	Set<Character> intersection = new HashSet<>(set1);
-	intersection.retainAll(set2);
-
-	Set<Character> union = new HashSet<>(set1);
-	union.addAll(set2);
-
-	return union.isEmpty() ? 0 : (double) intersection.size() / union.size();
-    }
-
     private void refilter() {
-	List<Result> found = new ArrayList<>();
-	String needle = sbox.text().toLowerCase();
-	// sequential substring matching
-	for(Result res : this.cur) {
-	    String haystack = res.btn.name().toLowerCase();
-	    int hayIndex = 0;
-	    boolean matches = true;
-
-	    for (char ch : needle.toCharArray()) {
-	        hayIndex = haystack.indexOf(ch, hayIndex);
-	        if (hayIndex == -1) {
-	            matches = false;
-	            break;
-	        }
-	        hayIndex++; // Move past the found character for the next search
-	    }
-
-	    if (matches)
-	        found.add(res);
-	}
-	// sort using jaccard similarity (common letters regardless relative positions)
-	found.sort(Comparator.comparingDouble(res -> -jaccardSimilarity(needle, res.btn.name().toLowerCase())));
+	List<Result> found = Fuzzy.fuzzyFilterAndSort(sbox.text().toLowerCase(), this.cur);
 	this.filtered = found;
 	int idx = filtered.indexOf(rls.sel);
 	if(idx < 0) {

--- a/src/haven/MenuSearch.java
+++ b/src/haven/MenuSearch.java
@@ -80,13 +80,49 @@ public class MenuSearch extends Window {
 	setroot(null);
     }
 
+    private double jaccardSimilarity(String str1, String str2) {
+	Set<Character> set1 = new HashSet<>();
+	Set<Character> set2 = new HashSet<>();
+
+	for (char ch : str1.toCharArray()) {
+	    set1.add(ch);
+	}
+	for (char ch : str2.toCharArray()) {
+	    set2.add(ch);
+	}
+
+	Set<Character> intersection = new HashSet<>(set1);
+	intersection.retainAll(set2);
+
+	Set<Character> union = new HashSet<>(set1);
+	union.addAll(set2);
+
+	return union.isEmpty() ? 0 : (double) intersection.size() / union.size();
+    }
+
     private void refilter() {
 	List<Result> found = new ArrayList<>();
 	String needle = sbox.text().toLowerCase();
+	// sequential substring matching
 	for(Result res : this.cur) {
-	    if(res.btn.name().toLowerCase().indexOf(needle) >= 0)
-		found.add(res);
+	    String haystack = res.btn.name().toLowerCase();
+	    int hayIndex = 0;
+	    boolean matches = true;
+
+	    for (char ch : needle.toCharArray()) {
+	        hayIndex = haystack.indexOf(ch, hayIndex);
+	        if (hayIndex == -1) {
+	            matches = false;
+	            break;
+	        }
+	        hayIndex++; // Move past the found character for the next search
+	    }
+
+	    if (matches)
+	        found.add(res);
 	}
+	// sort using jaccard similarity (common letters regardless relative positions)
+	found.sort(Comparator.comparingDouble(res -> -jaccardSimilarity(needle, res.btn.name().toLowerCase())));
 	this.filtered = found;
 	int idx = filtered.indexOf(rls.sel);
 	if(idx < 0) {

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -35,6 +35,7 @@ import haven.render.*;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
+import haven.Fuzzy;
 import haven.ItemInfo.AttrCache;
 import haven.res.ui.stackinv.ItemStack;
 import haven.resutil.Curiosity;
@@ -220,7 +221,7 @@ public class WItem extends Widget implements DTarget {
 		String itemName = item.getname().toLowerCase();
 		String searchKeyword = InventorySearchWindow.inventorySearchString.toLowerCase();
 		if (searchKeyword.length() > 1) {
-			if (itemName.contains(searchKeyword)) {
+			if (Fuzzy.fuzzyContains(itemName, searchKeyword)) {
 				int colorShiftSpeed = 800/GLPanel.Loop.fps;
 				if (searchItemColorShiftUp) {
 					if (searchItemColorValue + colorShiftSpeed <= 255) {


### PR DESCRIPTION
In menu search instead just filtering out these menu items that don't have specified substring we use more fuzzy approach. I've used Sequential Substring Matching along with Token Matching. Using these instead plain substring allows us to search more effectively because we don't need to provide exact prononciation, for example to search for tanning tub we could just write
"tant, tnb etc". 
![image](https://github.com/user-attachments/assets/a4e53847-eb24-4cf4-b0c0-4a5fd6b6e16c)
![image](https://github.com/user-attachments/assets/ebfec807-4f22-4c09-929b-0177bcc19ce1)
![image](https://github.com/user-attachments/assets/2da5add4-d350-4269-8099-703210c35d12)
