### PR TITLE
Added the ability to add kin from a text file

### DIFF
--- a/src/haven/BuddyWnd.java
+++ b/src/haven/BuddyWnd.java
@@ -26,9 +26,13 @@
 
 package haven;
 
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.Color;
+import java.io.*;
 import java.util.*;
 import java.text.Collator;
+import java.util.stream.Collectors;
 
 public class BuddyWnd extends Widget implements Iterable<BuddyWnd.Buddy> {
     private List<Buddy> buddies = new ArrayList<Buddy>();
@@ -493,7 +497,7 @@ public class BuddyWnd extends Widget implements Iterable<BuddyWnd.Buddy> {
 	             new Button(sbw, "Clear" ).action(() -> { setpwd(""); })
 	      );
 
-	prev = add(new Label("Add kin by Hearth Secret:"), prev.pos("bl").adds(0, 109));
+	prev = add(new Label("Add kin by Hearth Secret:"), prev.pos("bl").adds(0, 60));
 	opass = add(new TextEntry(UI.scale(140), "") {
 		public void activate(String text) {
 		    BuddyWnd.this.wdgmsg("bypwd", text);
@@ -504,6 +508,35 @@ public class BuddyWnd extends Widget implements Iterable<BuddyWnd.Buddy> {
 		    BuddyWnd.this.wdgmsg("bypwd", opass.text());
 		    opass.settext("");
 	}), opass.pos("bl").adds(0, 5));
+
+	prev = add(new Button(UI.scale(140), "Add kin from file").action(() -> {
+		java.awt.EventQueue.invokeLater(() -> {
+			try {
+				// Open a file chooser dialog for selecting a text file
+				JFileChooser fileChooser = new JFileChooser(System.getProperty("user.dir"));
+				fileChooser.setFileFilter(new FileNameExtensionFilter("Text files containing hearth secrets", "txt"));
+
+				// If no file is selected, exit the method
+				if (fileChooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) {
+					return;
+				}
+
+				File file = fileChooser.getSelectedFile();
+
+				final List<String> lines;
+				try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+					lines = reader.lines().collect(Collectors.toList());
+				}
+
+				lines.forEach(line -> {
+					BuddyWnd.this.wdgmsg("bypwd", line);
+				});
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		});
+	}), prev.pos("bl").adds(0, 5));
+
 	pack();
     }
 


### PR DESCRIPTION
**Changes**
- Added a button to the "Kin" menu that opens up a file chooser and allows the user to select a text file containing a list of hearth secrets. Once selected, all of the secrets will be added.

![image](https://github.com/user-attachments/assets/59f28971-5b8a-4613-b882-cfc2bf579c80)
![image](https://github.com/user-attachments/assets/c75aeed9-b50d-408b-bcdf-35c2c1ecd320)
![image](https://github.com/user-attachments/assets/a769d84a-86e4-488c-bf03-5ca7b201133f)
