### PR TITLE
Added "Chat Settings" window with various enhancements (Mute alerts, show kin status, auto-select new chats)

### DIFF
--- a/src/haven/BuddyWnd.java
+++ b/src/haven/BuddyWnd.java
@@ -132,7 +132,10 @@ public class BuddyWnd extends Widget implements Iterable<BuddyWnd.Buddy> {
 	}
 
 	private void chstatus(int status) {
-	    online = status;
+		online = status;
+		if (!OptWnd.showKinStatusChangeMessages.a) {
+			return;
+		}
 	    GameUI gui = getparent(GameUI.class);
 	    if(gui != null) {
 		ui.gui.msg(name + (online > 0 ? " is now ONLINE" : " has gone Offline"), BuddyWnd.gc[group]);

--- a/src/haven/ChatUI.java
+++ b/src/haven/ChatUI.java
@@ -1252,7 +1252,9 @@ public class ChatUI extends Widget {
 	    chan.resize(sz.x - marg.x - chan.c.x, sz.y - chan.c.y);
 	    super.add(w);
 	    chansel.add(chan);
-	    select(chan, false);
+		boolean autoSelect = OptWnd.autoSelectNewChatCheckBox.a;
+		if(autoSelect) select(chan, false);
+		if(!autoSelect) chan.hide();
 	    return(w);
 	} else {
 	    return(super.add(w));
@@ -1613,7 +1615,26 @@ public class ChatUI extends Widget {
 	    synchronized(notifs) {
 		notifs.addFirst(new Notification(chan, msg));
 	    }
-	    ui.sfx(notifsfx);
+
+		boolean playSound = OptWnd.chatAlertSoundsCheckBox.a;
+
+		if (chan instanceof PrivChat && playSound) {
+			playSound = OptWnd.privateChatAlertSoundsCheckBox.a;
+		}
+		else if (chan instanceof MultiChat && playSound) {
+			if (chan.name().equals("Area Chat")) {
+				playSound = OptWnd.areaChatAlertSoundsCheckBox.a;
+			}
+			else if (chan.name().equals("Party")) {
+				playSound = OptWnd.partyChatAlertSoundsCheckBox.a;
+			}
+			else if (chan.name().equals(OptWnd.villageNameTextEntry.text())) {
+				playSound = OptWnd.villageChatAlertSoundsCheckBox.a;
+			}
+		}
+
+		if(playSound) ui.sfx(notifsfx);
+
 	}
     }
 

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -1167,7 +1167,88 @@ public class OptWnd extends Window {
 		}
 	}
 
-			public static CheckBox toggleGobCollisionBoxesCheckBox;
+	public static CheckBox chatAlertSoundsCheckBox;
+	public static CheckBox areaChatAlertSoundsCheckBox;
+	public static CheckBox partyChatAlertSoundsCheckBox;
+	public static CheckBox privateChatAlertSoundsCheckBox;
+
+	public static TextEntry villageNameTextEntry;
+	public static CheckBox villageChatAlertSoundsCheckBox;
+	public static CheckBox autoSelectNewChatCheckBox;
+	public static CheckBox showKinStatusChangeMessages;
+
+	public class ChatSettingsPanel extends Panel {
+		public ChatSettingsPanel(Panel back) {
+			Widget prev;
+
+			prev = add(chatAlertSoundsCheckBox = new CheckBox("Enable chat alert sounds"){
+				{a = (Utils.getprefb("chatAlertSounds", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("chatAlertSounds", val);
+				}
+			}, 0, 0);
+
+			prev = add(areaChatAlertSoundsCheckBox = new CheckBox("Enable area chat alert sounds"){
+				{a = (Utils.getprefb("areaChatAlertSounds", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("areaChatAlertSounds", val);
+				}
+			}, prev.pos("bl").adds(20, 4));
+
+			prev = add(privateChatAlertSoundsCheckBox = new CheckBox("Enable private chat alert sounds"){
+				{a = (Utils.getprefb("privateChatAlertSounds", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("privateChatAlertSounds", val);
+				}
+			}, prev.pos("bl").adds(0, 4));
+
+			prev = add(partyChatAlertSoundsCheckBox = new CheckBox("Enable party chat alert sounds"){
+				{a = (Utils.getprefb("partyChatAlertSounds", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("partyChatAlertSounds", val);
+				}
+			}, prev.pos("bl").adds(0, 4));
+
+			prev = add(villageChatAlertSoundsCheckBox = new CheckBox("Enable village chat alert sounds"){
+				{
+					a = (Utils.getprefb("villageChatAlertSounds", true));
+					tooltip = RichText.render("You must set a village name below in order to configure the alerts properly.\n\nWithout setting a name, village alerts will default to the overall 'Enable chat alert sounds' setting.", UI.scale(300));
+				}
+				public void changed(boolean val) {
+					Utils.setprefb("villageChatAlertSounds", val);
+				}
+			}, prev.pos("bl").adds(0, 4));
+
+			prev = add(new Label("Village name for alerts:"), prev.pos("bl").adds(20, 4));
+			add(villageNameTextEntry = new TextEntry(UI.scale(100), Utils.getpref("villageNameForChatAlerts", "")){
+				protected void changed() {
+					Utils.setpref("villageNameForChatAlerts", this.buf.line());
+					super.changed();
+				}}, prev.pos("ur").adds(6, 0));
+
+			prev = add(autoSelectNewChatCheckBox = new CheckBox("Auto-select new chats"){
+				{a = (Utils.getprefb("autoSelectNewChat", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("autoSelectNewChat", val);
+				}
+			}, prev.pos("bl").adds(0, 4).x(0));
+
+			prev = add(showKinStatusChangeMessages = new CheckBox("Show kin status change messages"){
+				{a = (Utils.getprefb("showKinStatusChangeMessages", true));}
+				public void changed(boolean val) {
+					Utils.setprefb("showKinStatusChangeMessages", val);
+				}
+			}, prev.pos("bl").adds(0, 4));
+
+			Widget backButton;
+			add(backButton = new PButton(UI.scale(200), "Back", 27, back, "Advanced Settings"), prev.pos("bl").adds(0, 18).x(0));
+			pack();
+			centerBackButton(backButton, this);
+		}
+	}
+
+
+	public static CheckBox toggleGobCollisionBoxesCheckBox;
 	public static ColorOptionWidget collisionBoxColorOptionWidget;
 	public static String[] collisionBoxColorSetting = Utils.getprefsa("collisionBox" + "_colorSetting", new String[]{"255", "255", "255", "210"});
 	public static CheckBox displayObjectHealthPercentageCheckBox;
@@ -2216,7 +2297,7 @@ public class OptWnd extends Window {
 			public void changed(boolean val) {Utils.setprefb("wagonNearestLiftable_container", val);}}, objectsLiftActionLeft.pos("ur").adds(4, 0)).settip("Lift the nearest storage container into Wagon/Cart.");
 		objectsLiftActionLeft = cont.add(new CheckBox("Tree Logs"){{a = Utils.getprefb("wagonNearestLiftable_log", true);}
 			public void changed(boolean val) {Utils.setprefb("wagonNearestLiftable_log", val);}}, objectsLiftActionLeft.pos("bl").adds(0, 4)).settip("Lift nearest log into Wagon/Cart.");
-				
+
 		y+=UI.scale(40);
 		y = addbtn(cont, "Toggle Collision Boxes", GameUI.kb_toggleCollisionBoxes, y);
 		y = addbtn(cont, "Toggle Object Hiding", GameUI.kb_toggleHidingBoxes, y);
@@ -4217,6 +4298,7 @@ public class OptWnd extends Window {
 	// ND: Add the sub-panel buttons for the advanced settings here
 		Panel interfacesettings = add(new InterfaceSettingsPanel(advancedSettings));
 		Panel actionbarssettings =  add(new ActionBarsSettingsPanel(advancedSettings));
+		Panel chatsettings =  add(new ChatSettingsPanel(advancedSettings));
 		Panel displaysettings = add(new DisplaySettingsPanel(advancedSettings));
 		Panel qualitydisplaysettings = add(new QualityDisplaySettingsPanel(advancedSettings));
 		Panel gameplayautomationsettings = add(new GameplayAutomationSettingsPanel(advancedSettings));
@@ -4234,6 +4316,8 @@ public class OptWnd extends Window {
 		leftY = advancedSettings.add(new PButton(UI.scale(200), "Action Bars Settings", -1, actionbarssettings, "Action Bars Settings"), 0, leftY).pos("bl").adds(0, 5).y;
 		leftY = advancedSettings.add(new PButton(UI.scale(200), "Combat UI Settings", -1, combatuipanel, "Combat UI Settings"), 0, leftY).pos("bl").adds(0, 5).y;
 		leftY = advancedSettings.add(new PButton(UI.scale(200), "Quality Display Settings", -1, qualitydisplaysettings, "Quality Display Settings"), 0, leftY).pos("bl").adds(0, 5).y;
+		leftY = advancedSettings.add(new PButton(UI.scale(200), "Chat Settings", -1, chatsettings, "Chat Settings"), 0, leftY).pos("bl").adds(0, 5).y;
+
 		leftY += UI.scale(20);
 
 		leftY = advancedSettings.add(new PButton(UI.scale(200), "Altered Gameplay Settings", -1, alteredgameplaysettings, "Altered Gameplay Settings"), 0, leftY).pos("bl").adds(0, 5).y;
@@ -4245,7 +4329,8 @@ public class OptWnd extends Window {
 		rightY = advancedSettings.add(new PButton(UI.scale(200), "Camera Settings", -1, camsettings, "Camera Settings"), rightX, rightY).pos("bl").adds(0, 5).y;
 		rightY = advancedSettings.add(new PButton(UI.scale(200), "World Graphics Settings", -1, worldgraphicssettings, "World Graphics Settings"), rightX, rightY).pos("bl").adds(0, 5).y;
 		rightY = advancedSettings.add(new PButton(UI.scale(200), "Hiding Settings", -1, hidingsettings, "Hiding Settings"), rightX, rightY).pos("bl").adds(0, 5).y;
-		rightY += UI.scale(20);
+
+		rightY += UI.scale(50);
 		rightY = advancedSettings.add(new PButton(UI.scale(200), "Gameplay Automation Settings", -1, gameplayautomationsettings, "Gameplay Automation Settings"), rightX, rightY).pos("bl").adds(0, 5).y;
 		rightY = advancedSettings.add(new PButton(UI.scale(200), "Aggro Exclusion Settings", -1, combataggrosettings, "Aggro Exclusion Settings"), rightX, rightY).pos("bl").adds(0, 5).y;
 


### PR DESCRIPTION
Added a new "Chat Settings" window that allows you to configure:

**Chat alert sounds**
- Enable/Disable all chat alert sounds
- Enable/Disable specific channels: Area chat, Private Chat, Party Chat, Village Chat)
- NOTE: In order for village chat to work, the user must enter the name of their village. If one is not entered, it will fall back to the overall enable/disable chat alert sounds setting. The only other way I could find to figure out if a chat was a village was to look at the chat icon res file for the village flag but that sounds really hack-y and don't feel comfortable with that.

**Auto-select new chats**
- If enabled, when a new chat channel appears (e.g. you get a PM or join a party), your client will auto switch to that channel
- if disabled, the channel will appear but you will not be auto-switched to the channel

**Show kin status change messages**
- If enabled, kin status change messages will appear like normal in the "System" channel and above the chat box
- If disabled, the kin status change messages will be suppressed and not appear in either box
- NOTE: This could arguably be moved to "Interface Settings" but I chose to add it to the "Chat Settings" window since I was already there. Feel free to ask me to move it :).

Screenshots:
Setting windows:
![image](https://github.com/user-attachments/assets/4d1c3317-8b8e-4d0d-ab8e-2dcae0db8de1)
![image](https://github.com/user-attachments/assets/ea7d45bf-09bf-4994-bf85-0643a92646df)

Tooltip for the village chat alerts:
![image](https://github.com/user-attachments/assets/efd67fe7-5b23-4939-91b6-3ae0475ebe9d)

Auto-Select new chats on:
![image](https://github.com/user-attachments/assets/a637d363-cafd-434f-9995-1c47271e735c)

Auto-Select new chats off:
![image](https://github.com/user-attachments/assets/7b14aedb-3b5c-4859-88eb-31ee52adb90c)

Show kin status change messages on:
![image](https://github.com/user-attachments/assets/71acbd29-31fe-48bf-b8ff-c92f1653d58f)

Show kin status change messages off:
You'll just have to trust me that I logged my alt in 😆 
![image](https://github.com/user-attachments/assets/9ea30dcf-ce3f-4067-96ad-06c402e20cd3)


