### PR TITLE
Fixed left click detection on MenuSearch and getting stuck with the dragging

### DIFF
--- a/src/haven/MenuSearch.java
+++ b/src/haven/MenuSearch.java
@@ -49,10 +49,12 @@ public class MenuSearch extends Window {
 
 		    @Override public boolean mousedown(MouseDownEvent ev) {
 				super.mousedown(ev);
-
-				drag_start = ui.mc;
-				drag_mode = false;
-				grab = ui.grabmouse(this);
+				
+				if(ev.b == 1){
+					drag_start = ui.mc;
+					drag_mode = false;
+					grab = ui.grabmouse(this);
+				}
 
 				return(true);
 		    }


### PR DESCRIPTION
Fixed a bug where the MenuSearch was not looking for a left click, now it only allows left clicks to drag the icon.