### PR TITLE
[POC] Changed Settings to work with the newly added Settings Store

### DIFF
--- a/src/haven/AccountList.java
+++ b/src/haven/AccountList.java
@@ -13,7 +13,7 @@ public class AccountList extends Widget {
 
     static void loadAccounts() {
         accountmap.clear();
-        String[] savedAccounts = Utils.getprefsa("savedAccounts", null);
+        String[] savedAccounts = RegistryStore.getprefsa("savedAccounts", null);
         try {
             if (savedAccounts != null) {
                 for (String s : savedAccounts) {
@@ -51,7 +51,7 @@ public class AccountList extends Widget {
                     savedAccounts[i] = e.getKey() + ";" + e.getValue();
                     i++;
                 }
-                Utils.setprefsa("savedAccounts", savedAccounts);
+                RegistryStore.setprefsa("savedAccounts", savedAccounts);
             } catch(Exception e) {
                 e.printStackTrace();
             }

--- a/src/haven/AuthClient.java
+++ b/src/haven/AuthClient.java
@@ -136,12 +136,12 @@ public class AuthClient implements Closeable {
 
 	public static TokenInfo forhost() {
 	    TokenInfo ret = new TokenInfo();
-	    if((ret.id = Utils.getprefb("token-id", ret.id)).length == 0) {
+	    if((ret.id = RegistryStore.getprefb("token-id", ret.id)).length == 0) {
 		ret.id = new byte[16];
 		new SecureRandom().nextBytes(ret.id);
-		Utils.setprefb("token-id", ret.id);
+		RegistryStore.setprefb("token-id", ret.id);
 	    }
-	    if((ret.desc = Utils.getpref("token-desc", null)) == null) {
+	    if((ret.desc = RegistryStore.getpref("token-desc", null)) == null) {
 		try {
 		    ret.desc = InetAddress.getLocalHost().getHostName();
 		} catch(UnknownHostException e) {

--- a/src/haven/BaseFileCache.java
+++ b/src/haven/BaseFileCache.java
@@ -37,46 +37,17 @@ public class BaseFileCache implements ResCache {
     public final URI id;
     private final Path base;
 
-    public static Path findroot() {
-	try {
-	    windows: {
-		String path = System.getenv("APPDATA");
-		if(path == null)
-		    break windows;
-		Path appdata = Utils.path(path);
-		if(!Files.exists(appdata) || !Files.isDirectory(appdata) || !Files.isReadable(appdata) || !Files.isWritable(appdata))
-		    break windows;
-		Path base = pj(appdata, "Haven and Hearth", "cache");
-		if(!Files.exists(base)) {
-		    try {
-			Files.createDirectories(base);
-		    } catch(IOException e) {
-			break windows;
-		    }
-		}
-		return(base);
-	    }
-	    fallback: {
-		String path = System.getProperty("user.home", null);
-		if(path == null)
-		    break fallback;
-		Path home = Utils.path(path);
-		if(!Files.exists(home) || !Files.isDirectory(home) || !Files.isReadable(home) || !Files.isWritable(home))
-		    break fallback;
-		Path base = pj(home, ".haven", "cache");
-		if(!Files.exists(base)) {
-		    try {
-			Files.createDirectories(base);
-		    } catch(IOException e) {
-			break fallback;
-		    }
-		}
-		return(base);
-	    }
-	} catch(SecurityException e) {
+	public static Path findroot() {
+        Path base = pj(Utils.getStorageDirectory(), "cache");
+        if(!Files.exists(base)) {
+            try {
+                Files.createDirectories(base);
+            } catch(IOException e) {
+                throw(new UnsupportedOperationException("Found no reasonable place to store local files"));
+            }
+        }
+        return(base);
 	}
-	throw(new UnsupportedOperationException("Found no reasonable place to store local files"));
-    }
 
     public static Path findbase(URI id) throws IOException {
 	String idstr = id.toString();

--- a/src/haven/Bootstrap.java
+++ b/src/haven/Bootstrap.java
@@ -88,15 +88,15 @@ public class Bootstrap implements UI.Receiver, UI.Runner {
     }
 
     private String getpref(String name, String def) {
-	return(Utils.getpref(name + "@" + hostname, def));
+	return(RegistryStore.getpref(name + "@" + hostname, def));
     }
 
     private void setpref(String name, String val) {
-	Utils.setpref(name + "@" + hostname, val);
+		RegistryStore.setpref(name + "@" + hostname, val);
     }
 
     private static byte[] getprefb(String name, String hostname, byte[] def, boolean zerovalid) {
-	String sv = Utils.getpref(name + "@" + hostname, null);
+	String sv = RegistryStore.getpref(name + "@" + hostname, null);
 	if(sv == null)
 	    return(def);
 	byte[] ret = Utils.hex2byte(sv);
@@ -118,18 +118,18 @@ public class Bootstrap implements UI.Receiver, UI.Runner {
     }
 
     public static void rottokens(String user, String hostname, boolean creat, boolean rm) {
-	List<String> names = new ArrayList<>(Utils.getprefsl("saved-tokens@" + hostname, new String[] {}));
+	List<String> names = new ArrayList<>(RegistryStore.getprefsl("saved-tokens@" + hostname, new String[] {}));
 	creat = creat || (!rm && names.contains(user));
 	if(rm || creat)
 	    names.remove(user);
 	if(creat)
 	    names.add(0, user);
-	Utils.setprefsl("saved-tokens@" + hostname, names);
+		RegistryStore.setprefsl("saved-tokens@" + hostname, names);
     }
 
     public static void settoken(String user, String hostname, byte[] token) {
 	String prefnm = user;
-	Utils.setpref("savedtoken-" + mangleuser(user) + "@" + hostname, (token == null) ? "" : Utils.byte2hex(token));
+	RegistryStore.setpref("savedtoken-" + mangleuser(user) + "@" + hostname, (token == null) ? "" : Utils.byte2hex(token));
 	rottokens(user, hostname, token != null, true);
     }
 

--- a/src/haven/HashDirCache.java
+++ b/src/haven/HashDirCache.java
@@ -38,46 +38,17 @@ public class HashDirCache implements ResCache {
     public final URI id;
     private final long idhash;
 
-    public static Path findbase() {
-	try {
-	    windows: {
-		String path = System.getenv("APPDATA");
-		if(path == null)
-		    break windows;
-		Path appdata = Utils.path(path);
-		if(!Files.exists(appdata) || !Files.isDirectory(appdata) || !Files.isReadable(appdata) || !Files.isWritable(appdata))
-		    break windows;
-		Path base = pj(appdata, "Haven and Hearth", "data");
-		if(!Files.exists(base)) {
-		    try {
-			Files.createDirectories(base);
-		    } catch(IOException e) {
-			break windows;
-		    }
-		}
-		return(base);
-	    }
-	    fallback: {
-		String path = System.getProperty("user.home", null);
-		if(path == null)
-		    break fallback;
-		Path home = Utils.path(path);
-		if(!Files.exists(home) || !Files.isDirectory(home) || !Files.isReadable(home) || !Files.isWritable(home))
-		    break fallback;
-		Path base = pj(home, ".haven", "data");
-		if(!Files.exists(base)) {
-		    try {
-			Files.createDirectories(base);
-		    } catch(IOException e) {
-			break fallback;
-		    }
-		}
-		return(base);
-	    }
-	} catch(SecurityException e) {
+	public static Path findbase() {
+		Path base = pj(Utils.getStorageDirectory(), "data");
+        if(!Files.exists(base)) {
+            try {
+                Files.createDirectories(base);
+            } catch(IOException e) {
+                throw(new UnsupportedOperationException("Found no reasonable place to store local files"));
+            }
+        }
+        return(base);
 	}
-	throw(new UnsupportedOperationException("Found no reasonable place to store local files"));
-    }
 
     private HashDirCache(URI id) {
 	this.base = findbase();

--- a/src/haven/LoginScreen.java
+++ b/src/haven/LoginScreen.java
@@ -70,7 +70,7 @@ public class LoginScreen extends Widget {
 
 
     private String getpref(String name, String def) {
-	return(Utils.getpref(name + "@" + hostname, def));
+	return(RegistryStore.getpref(name + "@" + hostname, def));
     }
 
     public LoginScreen(String hostname) {
@@ -179,7 +179,7 @@ public class LoginScreen extends Widget {
 
 	    private UserEntry(int w) {
 		super(w, "");
-//		history.addAll(Utils.getprefsl("saved-tokens@" + hostname, new String[] {}));
+//		history.addAll(RegistryStore.getprefsl("saved-tokens@" + hostname, new String[] {}));
 	    }
 
 	    protected void changed() {

--- a/src/haven/MainFrame.java
+++ b/src/haven/MainFrame.java
@@ -130,14 +130,14 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 			    h = Integer.parseInt(args[2]);
 			p.setSize(w, h);
 			pack();
-			Utils.setprefc("wndsz", new Coord(w, h));
+			RegistryStore.setprefc("wndsz", new Coord(w, h));
 		    } else if(args.length == 2) {
 			if(args[1].equals("dyn")) {
 			    setResizable(true);
-			    Utils.setprefb("wndlock", false);
+			    RegistryStore.setprefb("wndlock", false);
 			} else if(args[1].equals("lock")) {
 			    setResizable(false);
-			    Utils.setprefb("wndlock", true);
+			    RegistryStore.setprefb("wndlock", true);
 			}
 		    }
 		}
@@ -146,13 +146,13 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 		public void run(Console cons, String[] args) throws Exception {
 		    if((args.length < 2) || args[1].equals("none")) {
 			fsmode = null;
-			Utils.setprefc("fsmode", Coord.z);
+			RegistryStore.setprefc("fsmode", Coord.z);
 		    } else if(args.length == 3) {
 			DisplayMode mode = findmode(Integer.parseInt(args[1]), Integer.parseInt(args[2]));
 			if(mode == null)
 			    throw(new Exception("No such mode is available"));
 			fsmode = mode;
-			Utils.setprefc("fsmode", new Coord(mode.getWidth(), mode.getHeight()));
+			RegistryStore.setprefc("fsmode", new Coord(mode.getWidth(), mode.getHeight()));
 		    }
 		}
 	    });
@@ -205,7 +205,7 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 	super("Haven & Hearth");
 	Coord sz;
 	if(isz == null) {
-		sz = Utils.getprefc("wndsz", new Coord(1067, 600)); // ND: This affects the game window size on startup
+		sz = RegistryStore.getprefc("wndsz", new Coord(1067, 600)); // ND: This affects the game window size on startup
 	    if(sz.x < 1067) sz.x = 1067;
 	    if(sz.y < 600) sz.y = 600;
 	} else {
@@ -214,14 +214,14 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 	this.g = new ThreadGroup(HackThread.tg(), "Haven client");
 	Component pp = (Component)(this.p = renderer());
 	if(fsmode == null) {
-	    Coord pfm = Utils.getprefc("fsmode", null);
+	    Coord pfm = RegistryStore.getprefc("fsmode", null);
 	    if((pfm != null) && !pfm.equals(Coord.z))
 		fsmode = findmode(pfm.x, pfm.y);
 	}
 	add(pp);
 	pp.setSize(sz.x, sz.y);
 	pack();
-	setResizable(!Utils.getprefb("wndlock", false));
+	setResizable(!RegistryStore.getprefb("wndlock", false));
 	pp.requestFocus();
 	seticon();
 	setVisible(true);
@@ -238,7 +238,7 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 		    p.background(true);
 		}
 	    });
-	if((isz == null) && Utils.getprefb("wndmax", false))
+	if((isz == null) && RegistryStore.getprefb("wndmax", false))
 	    setExtendedState(getExtendedState() | MAXIMIZED_BOTH);
 
 	this.getToolkit().addAWTEventListener(this, AWTEvent.KEY_EVENT_MASK); // ND: Do this to prevent F10 or ALT from defocusing the game window when released
@@ -265,9 +265,9 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 		 * ought to correspond to the inner size at all
 		 * times. */{
 		Dimension dim = p.getSize();
-		Utils.setprefc("wndsz", new Coord(dim.width, dim.height));
+		RegistryStore.setprefc("wndsz", new Coord(dim.width, dim.height));
 	    }
-	    Utils.setprefb("wndmax", (getExtendedState() & MAXIMIZED_BOTH) != 0);
+	    RegistryStore.setprefb("wndmax", (getExtendedState() & MAXIMIZED_BOTH) != 0);
 	}
     }
 
@@ -287,10 +287,10 @@ public class MainFrame extends java.awt.Frame implements Console.Directory, AWTE
 	    if(Bootstrap.authuser.get() != null) {
 		username = Bootstrap.authuser.get();
 	    } else {
-		if((username = Utils.getpref("tokenname@" + Bootstrap.defserv.get(), null)) == null)
+		if((username = RegistryStore.getpref("tokenname@" + Bootstrap.defserv.get(), null)) == null)
 		    throw(new ConnectionError("no explicit or saved username for host: " + Bootstrap.defserv.get()));
 	    }
-	    String token = Utils.getpref("savedtoken-" + username + "@" + Bootstrap.defserv.get(), null);
+	    String token = RegistryStore.getpref("savedtoken-" + username + "@" + Bootstrap.defserv.get(), null);
 	    if(token == null)
 		throw(new ConnectionError("no saved token for user: " + username));
 	    try {

--- a/src/haven/RegistryStore.java
+++ b/src/haven/RegistryStore.java
@@ -1,0 +1,189 @@
+package haven;
+
+import java.util.prefs.*;
+import org.json.JSONArray;
+import java.util.*;
+import java.nio.*;
+
+public class RegistryStore {
+    public static final Config.Variable<String> prefspec = Config.Variable.prop("haven.prefspec", "hafen-Hurricane");
+    public static Preferences prefs() {
+        return Utils.prefs();
+    }
+
+    public static String getpref(String prefname, String def) {
+	try {
+	    return(prefs().get(prefname, def));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setpref(String prefname, String val) {
+	try {
+	    if(val == null)
+		prefs().remove(prefname);
+	    else
+		prefs().put(prefname, val);
+	} catch(SecurityException e) {
+	}
+    }
+
+	static String[] getprefsa(String prefname, String[] def) { // ND: Get prefs array
+		try {
+			String jsonstr = getpref(prefname, null);
+			if (jsonstr == null)
+				return def;
+			JSONArray ja = new JSONArray(jsonstr);
+			String[] ra = new String[ja.length()];
+			for (int i = 0; i < ja.length(); i++)
+				ra[i] = ja.getString(i);
+			return ra;
+		} catch (SecurityException e) {
+			return def;
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			return def;
+		}
+	}
+
+	static void setprefsa(String prefname, String[] val) { // ND: Set prefs array
+		try {
+			String jsonarr = "";
+			for (String s : val)
+				jsonarr += "\"" + s + "\",";
+			if (jsonarr.length() > 0)
+				jsonarr = jsonarr.substring(0, jsonarr.length() - 1);
+			setpref(prefname, "[" + jsonarr + "]");
+		} catch (SecurityException e) {
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+	}
+
+    public static int getprefi(String prefname, int def) {
+	try {
+	    return(prefs().getInt(prefname, def));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setprefi(String prefname, int val) {
+	try {
+	    prefs().putInt(prefname, val);
+	} catch(SecurityException e) {
+	}
+    }
+
+    public static double getprefd(String prefname, double def) {
+	try {
+	    return(prefs().getDouble(prefname, def));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setprefd(String prefname, double val) {
+	try {
+	    prefs().putDouble(prefname, val);
+	} catch(SecurityException e) {
+	}
+    }
+
+    public static boolean getprefb(String prefname, boolean def) {
+	try {
+	    return(prefs().getBoolean(prefname, def));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setprefb(String prefname, boolean val) {
+	try {
+	    prefs().putBoolean(prefname, val);
+	} catch(SecurityException e) {
+	}
+    }
+
+    public static Coord getprefc(String prefname, Coord def) {
+	try {
+	    String val = prefs().get(prefname, null);
+	    if(val == null)
+		return(def);
+	    int x = val.indexOf('x');
+	    if(x < 0)
+		return(def);
+	    return(new Coord(Integer.parseInt(val.substring(0, x)), Integer.parseInt(val.substring(x + 1))));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setprefc(String prefname, Coord val) {
+	try {
+	    String enc = (val == null) ? "" : val.x + "x" + val.y;
+	    prefs().put(prefname, enc);
+	} catch(SecurityException e) {
+	}
+    }
+
+    public static byte[] getprefb(String prefname, byte[] def) {
+	try {
+	    return(prefs().getByteArray(prefname, def));
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+
+    public static void setprefb(String prefname, byte[] val) {
+	try {
+	    prefs().putByteArray(prefname, val);
+	} catch(SecurityException e) {
+	}
+    }
+
+    public static List<String> getprefsl(String prefname, String[] def) {
+	byte[] enc = getprefb(prefname, null);
+	if(enc == null)
+	    return((def == null) ? null : Arrays.asList(def));
+	ByteBuffer buf = ByteBuffer.wrap(enc);
+	ArrayList<String> ret = new ArrayList<>();
+	for(int i = 0, s = 0; i < buf.capacity(); i++) {
+	    if(buf.get(i) == 0) {
+		buf.position(s).limit(i);
+		CharBuffer dec = Utils.utf8.decode(buf);
+		ret.add(dec.toString());
+		s = i + 1;
+		buf.limit(buf.capacity());
+	    }
+	}
+	ret.trimToSize();
+	return(ret);
+    }
+
+    public static void setprefsl(String prefname, Iterable<? extends CharSequence> val) {
+	ByteBuffer buf = ByteBuffer.allocate(1024);
+	for(CharSequence str : val) {
+	    ByteBuffer enc = Utils.utf8.encode(CharBuffer.wrap(str));
+	    buf = Utils.growbuf(buf, enc.remaining() + 1);
+	    buf.put(enc);
+	    buf.put((byte)0);
+	}
+	buf.flip();
+	byte[] enc = new byte[buf.remaining()];
+	buf.get(enc);
+	setprefb(prefname, enc);
+    }
+
+    public static String getprop(String propname, String def) {
+	try {
+	    String ret;
+	    if((ret = System.getProperty(propname)) != null)
+		return(ret);
+	    return(def);
+	} catch(SecurityException e) {
+	    return(def);
+	}
+    }
+}

--- a/src/haven/SettingsStore.java
+++ b/src/haven/SettingsStore.java
@@ -1,0 +1,145 @@
+package haven;
+
+import java.sql.Connection;
+import java.sql.*;
+import java.io.*;
+
+public class SettingsStore {
+    private Connection connection;
+
+    // Constructor to initialize the database connection
+    public SettingsStore(String dbPath) throws SQLException{
+        this.connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+        initializeDatabase();
+    }
+
+    // Initialize the database (create the settings table if it doesn't exist)
+    private void initializeDatabase() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS settings (" +
+                     "key TEXT PRIMARY KEY, " +
+                     "type TEXT NOT NULL, " +
+                     "value BLOB)";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+    
+    // Set a value for a key (store as BLOB)
+    public void set(String key, Object value) {
+        try {
+            if (value == null) {
+                // If the value is null, delete the record
+                delete(key);
+                return;
+            }
+
+            // Serialize the value to a byte array
+            byte[] byteValue = serialize(value);
+
+            // Determine the type of the value
+            String type = value.getClass().getSimpleName();
+
+            // Insert or replace the key-value pair
+            String sql = "INSERT OR REPLACE INTO settings (key, type, value) VALUES (?, ?, ?)";
+            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+                pstmt.setString(1, key);
+                pstmt.setString(2, type);
+                pstmt.setBytes(3, byteValue);
+                pstmt.executeUpdate();
+            }
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+    }
+
+    // Get a value by key (deserialize from BLOB)
+    public Object get(String key, Object defaultValue){
+        String sql = "SELECT value FROM settings WHERE key = ?;";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, key);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    byte[] byteValue = rs.getBytes("value");
+                    return deserialize(byteValue);
+                }
+            }
+        }catch(Exception e){
+            e.printStackTrace();
+        }
+        return defaultValue; // Return default value if key not found
+    }
+
+    // Delete a key-value pair
+    public void delete(String key) throws SQLException {
+        String sql = "DELETE FROM settings WHERE key = ?;";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, key);
+            pstmt.executeUpdate();
+        }
+    }
+
+    // Serialize an object to a byte array
+    private byte[] serialize(Object obj) throws IOException {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(obj);
+            return bos.toByteArray();
+        }
+    }
+
+    // Deserialize a byte array to an object
+    private Object deserialize(byte[] byteValue) throws IOException, ClassNotFoundException {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(byteValue);
+             ObjectInputStream ois = new ObjectInputStream(bis)) {
+            return ois.readObject();
+        }
+    }
+
+    // Close the database connection
+    public void close() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    // Type-specific getters and setters with default values
+    public void setInt(String key, Integer value){
+        set(key, value);
+    }
+
+    public Integer getInt(String key, Integer defaultValue){
+        return (Integer) get(key, defaultValue);
+    }
+
+    public void setString(String key, String value){
+        set(key, value);
+    }
+
+    public String getString(String key, String defaultValue) {
+        return (String) get(key, defaultValue);
+    }
+
+    public void setDouble(String key, Double value){
+        set(key, value);
+    }
+
+    public Double getDouble(String key, Double defaultValue){
+        return (Double) get(key, defaultValue);
+    }
+
+    public void setBoolean(String key, Boolean value){
+        set(key, value);
+    }
+
+    public Boolean getBoolean(String key, Boolean defaultValue){
+        return (Boolean) get(key, defaultValue);
+    }
+
+    public void setByteArray(String key, byte[] value){
+        set(key, value);
+    }
+
+    public byte[] getByteArray(String key, byte[] defaultValue){
+        return (byte[]) get(key, defaultValue);
+    }
+}

--- a/src/haven/SettingsStore.java
+++ b/src/haven/SettingsStore.java
@@ -1,8 +1,14 @@
 package haven;
 
 import java.sql.Connection;
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
 import java.sql.*;
 import java.io.*;
+import org.json.JSONObject;
 
 public class SettingsStore {
     private Connection connection;
@@ -141,5 +147,107 @@ public class SettingsStore {
 
     public byte[] getByteArray(String key, byte[] defaultValue){
         return (byte[]) get(key, defaultValue);
+    }
+
+    // Export settings to a JSON file
+    public void exportToJson(String filePath) throws SQLException, IOException, ClassNotFoundException {
+        Map<String, Object> jsonMap = new TreeMap<>();
+        String sql = "SELECT key, type, value FROM settings";
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                String key = rs.getString("key");
+                String type = rs.getString("type");
+                byte[] byteValue = rs.getBytes("value");
+                Object value = deserialize(byteValue);
+
+                // Convert value to appropriate JSON type
+                switch (type) {
+                    case "Integer":
+                        jsonMap.put(key, (Integer) value);
+                        break;
+                    case "String":
+                        jsonMap.put(key, (String) value);
+                        break;
+                    case "Double":
+                        jsonMap.put(key, (Double) value);
+                        break;
+                    case "Boolean":
+                        jsonMap.put(key, (Boolean) value);
+                        break;
+                    case "Byte[]":
+                        break;
+                        // Do not export bytearrays
+                        //json.put(key, new String((byte[]) value));
+                        //break;
+                    default:
+                        jsonMap.put(key, value.toString());
+                        break;
+                }
+            }
+        }
+
+        // Write JSON to file
+        try (FileWriter file = new FileWriter(filePath)) {
+            // Use a custom method to serialize the map with proper formatting
+            String jsonString = serializeMap(jsonMap);
+            file.write(jsonString);
+        }
+    }
+    // Helper method to serialize the map with proper formatting
+    //   Needed to serialize doubles with .0 if they are whole numbers
+    private String serializeMap(Map<String, Object> map) {
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append("{\n");
+        int size = map.size();
+        int count = 0;
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            jsonBuilder.append("    \"").append(key).append("\": ");
+            if (value instanceof Integer) {
+                // Serialize integers as-is
+                jsonBuilder.append(value);
+            } else if (value instanceof Double) {
+                // Serialize doubles with .0 if they are whole numbers
+                double doubleValue = (Double) value;
+                if (doubleValue == (long) doubleValue) {
+                    jsonBuilder.append(String.format("%.1f", doubleValue)); // Add .0
+                } else {
+                    jsonBuilder.append(doubleValue); // Keep as-is
+                }
+            } else if (value instanceof String) {
+                // Serialize strings with quotes
+                jsonBuilder.append("\"").append(value).append("\"");
+            } else if (value instanceof Boolean) {
+                // Serialize booleans as-is
+                jsonBuilder.append(value);
+            } else {
+                // Fallback for other types
+                jsonBuilder.append("\"").append(value.toString()).append("\"");
+            }
+            if (++count < size) {
+                jsonBuilder.append(",");
+            }
+            jsonBuilder.append("\n");
+        }
+        jsonBuilder.append("}");
+        return jsonBuilder.toString();
+    }
+    // Import settings from a JSON file
+    public void importFromJson(String filePath) throws IOException, SQLException {
+        StringBuilder jsonContent = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                jsonContent.append(line);
+            }
+        }
+
+        JSONObject json = new JSONObject(jsonContent.toString());
+        for (String key : json.keySet()) {
+            Object value = json.get(key);
+            set(key, value);
+        }
     }
 }


### PR DESCRIPTION
added `SettingsStore`, which does store all settings in an sqlite file
this file is stored where the client data is stored (appdata or .haven)
the storage path is now getting pulled from `Utils.getStorageDirectory()`, changed `BaseFileCache` and `HashDirCache` to also use that function for the next world change of a changed storage location (only need to change one piece of code)

This is meant for testing purposes:
One problem that I see is that the account token will also be saved in this sqlite file, which poses a threat if people would share there settings file :|

Things that need to be added is an import and export