### PR TITLE
Make pfWait wait until movement ends

### DIFF
--- a/src/haven/automated/AUtils.java
+++ b/src/haven/automated/AUtils.java
@@ -241,11 +241,12 @@ public class AUtils {
         int time = 0;
         boolean moved = false;
         Thread.sleep(300);
-        while (gui.map.pfthread.isAlive()) {
+        while (gui.map.pfthread.isAlive() || gui.map.player().getv() > 0) {
             time += 70;
             Thread.sleep(70);
             if (gui.map.player().getv() > 0) {
                 time = 0;
+                moved = true;
             }
             if (time > 2000 && moved == false) {
                 System.out.println("TRYING UNSTUCK");


### PR DESCRIPTION
Currently, the pathfinding thread can end before the last step of movement is done. This fixes it to wait until all movement is finished before ending.

This behavior appears to be expected in existing code - e.g. [TarKilnCleanerBot](https://github.com/Nightdawg/Hurricane/blob/d39f418f4db484732dbda6be8f502c0b7f9534c2/src/haven/automated/TarKilnCleanerBot.java#L76) checks if it's in range immediately after pfWait, when with current behavior, it'd need to wait until pfWait is successful and movement is done.