### PR TITLE
Enable automation to understand collision boxes

### DIFF
--- a/src/haven/automated/OceanScoutBot.java
+++ b/src/haven/automated/OceanScoutBot.java
@@ -190,7 +190,7 @@ public class OceanScoutBot extends Window implements Runnable {
     private boolean isGobCollision(Coord t) {
         for (Gob gob : nearbyGobs) {
             if (gob != null && gob.getres() != null) {
-                if (Pathfinder.isInsideBoundBox(gob.rc.floor(), gob.a, gob.getres().name, t)) {
+                if (Pathfinder.isInsideBoundBox(gob, t)) {
                     return true;
                 }
             }

--- a/src/haven/automated/helpers/HitBoxes.java
+++ b/src/haven/automated/helpers/HitBoxes.java
@@ -10,6 +10,8 @@ import java.util.*;
 public class HitBoxes {
     private static final String DATABASE = "jdbc:sqlite:static_data.db";
     public static Map<String, CollisionBox[]> collisionBoxMap = new HashMap<>();
+    private static CollisionBox[] PASSABLE_HITBOX = new CollisionBox[]{new CollisionBox(false)};
+    private static CollisionBox[] NO_HITBOX_FOUND = new CollisionBox[0];
 
     private static Set<String> passableGobs = new HashSet<>(Arrays.asList(
             "gfx/terobjs/herbs", "gfx/terobjs/items", "gfx/terobjs/plants", "gfx/terobjs/clue", "gfx/terobjs/boostspeed",
@@ -46,23 +48,29 @@ public class HitBoxes {
                 new Coord(-4, -2), new Coord(5, 2), new Coord(5, -2), new Coord(-4, 2))});
         collisionBoxMap.put("gfx/kritter/sheep/sheep", new CollisionBox[]{new CollisionBox(
                 new Coord(-4, -2), new Coord(5, 2), new Coord(5, -2), new Coord(-4, 2))});
+        try {
+            createDatabaseIfNotExist();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-
-
-    public static void addHitBox(Gob gob){
+    public static CollisionBox[] getCollisionBoxes(Gob gob) {
         Resource res = gob.getres();
-        if(collisionBoxMap.get(res.name) == null){
+        if (collisionBoxMap.get(res.name) == null) {
             for (String gobResName : passableGobs) {
                 if (res.name.contains(gobResName) && !res.name.contains("trellis")) {
-                    collisionBoxMap.put(res.name, new CollisionBox[]{new CollisionBox(false)});
-                    return;
+                    collisionBoxMap.put(res.name, PASSABLE_HITBOX);
+                    return PASSABLE_HITBOX;
                 }
             }
             try {
-                extractCollisionBoxesFromResource(gob);
-            } catch (Loading ignored){}
+                return extractCollisionBoxesFromResource(gob);
+            } catch (Loading ignored) {
+            }
         }
+
+        return collisionBoxMap.getOrDefault(res.name, NO_HITBOX_FOUND);
     }
 
     private static CollisionBox[] extractCollisionBoxesFromResource(Gob gob) {

--- a/src/haven/automated/pathfinder/Dbg.java
+++ b/src/haven/automated/pathfinder/Dbg.java
@@ -69,7 +69,7 @@ public class Dbg {
             String time = new SimpleDateFormat("MMdd_HHmmss").format(Calendar.getInstance().getTime());
             try {
                 new File("pf").mkdirs();
-                ImageIO.write(img, "png", new File("pf/pf-" + time + "-map"));
+                ImageIO.write(img, "png", new File("pf/pf-" + time + "-map.png"));
             } catch (Exception e) {
             }
         }
@@ -80,7 +80,7 @@ public class Dbg {
             String time = new SimpleDateFormat("MMdd_HHmmss").format(Calendar.getInstance().getTime());
             try {
                 new File("pf").mkdirs();
-                ImageIO.write(img, "png", new File("pf/pf-" + time));
+                ImageIO.write(img, "png", new File("pf/pf-" + time + ".png"));
             } catch (Exception e) {
             }
         }

--- a/src/haven/automated/pathfinder/Map.java
+++ b/src/haven/automated/pathfinder/Map.java
@@ -41,8 +41,8 @@ public class Map {
     private Vertex vxend;
 
     private final Dbg dbg;
-    private final static boolean DEBUG = false;
-    public final static boolean DEBUG_TIMINGS = false;
+    private final static boolean DEBUG = true;
+    public final static boolean DEBUG_TIMINGS = true;
 
     public Map(Coord plc, Coord endc, MCache mcache) {
         this.plc = plc;
@@ -140,50 +140,47 @@ public class Map {
             return;
         }
 
-        if (HitBoxes.collisionBoxMap.get(gob.getres().name) != null) {
-            HitBoxes.CollisionBox[] collisionBoxes = HitBoxes.collisionBoxMap.get(gob.getres().name);
-            if (gob.getres().name.contains("/pow")) {
-                Resource res = gob.getres();
-                ResDrawable rd = gob.getattr(ResDrawable.class);
-                if (rd != null) {
-                    if (res.name.endsWith("/pow") && (rd.sdt.checkrbuf(0) != 33 && rd.sdt.checkrbuf(0) != 17)) {
-                        addGobToList(new Coord(-4, -4), new Coord(4, 4), gob);
-                    }
+        if (gob.getres().name.contains("/pow")) {
+            Resource res = gob.getres();
+            ResDrawable rd = gob.getattr(ResDrawable.class);
+            if (rd != null) {
+                if (res.name.endsWith("/pow") && (rd.sdt.checkrbuf(0) != 33 && rd.sdt.checkrbuf(0) != 17)) {
+                    addGobToList(new Coord(-4, -4), new Coord(4, 4), gob);
                 }
-            } else if (gob.getres().name.contains("gate")){
-                Resource res = gob.getres();
-                ResDrawable rd = gob.getattr(ResDrawable.class);
-                if (rd != null){
-                    if (res.name.contains("gate") && (rd.sdt.checkrbuf(0) != 1)){
-                        if(gob.getres().name.contains("big")){
-                            addGobToList(new Coord(-5, -16), new Coord(5, 16), gob);
-                        } else {
-                            addGobToList(new Coord(-5, -11), new Coord(5, 11), gob);
-                        }
-                    }
-                }
-            } else {
-                for (HitBoxes.CollisionBox collisionBox : collisionBoxes) {
-                    if (!collisionBox.hitAble) {
-                        return;
+            }
+        } else if (gob.getres().name.contains("gate")){
+            Resource res = gob.getres();
+            ResDrawable rd = gob.getattr(ResDrawable.class);
+            if (rd != null){
+                if (res.name.contains("gate") && (rd.sdt.checkrbuf(0) != 1)){
+                    if(gob.getres().name.contains("big")){
+                        addGobToList(new Coord(-5, -16), new Coord(5, 16), gob);
                     } else {
-                        if (collisionBox.coords == null || collisionBox.coords.length < 3) {
-                            return;
-                        }
-
-                        double minX = Double.MAX_VALUE;
-                        double minY = Double.MAX_VALUE;
-                        double maxX = Double.MIN_VALUE;
-                        double maxY = Double.MIN_VALUE;
-
-                        for (Coord2d coord : collisionBox.coords) {
-                            minX = Math.min(minX, coord.x);
-                            minY = Math.min(minY, coord.y);
-                            maxX = Math.max(maxX, coord.x);
-                            maxY = Math.max(maxY, coord.y);
-                        }
-                        addGobToList(new Coord2d(minX, minY).floor(), new Coord2d(maxX, maxY).floor(), gob);
+                        addGobToList(new Coord(-5, -11), new Coord(5, 11), gob);
                     }
+                }
+            }
+        } else {
+            for (HitBoxes.CollisionBox collisionBox : HitBoxes.getCollisionBoxes(gob)) {
+                if (!collisionBox.hitAble) {
+                    return;
+                } else {
+                    if (collisionBox.coords == null || collisionBox.coords.length < 3) {
+                        return;
+                    }
+
+                    double minX = Double.MAX_VALUE;
+                    double minY = Double.MAX_VALUE;
+                    double maxX = Double.MIN_VALUE;
+                    double maxY = Double.MIN_VALUE;
+
+                    for (Coord2d coord : collisionBox.coords) {
+                        minX = Math.min(minX, coord.x);
+                        minY = Math.min(minY, coord.y);
+                        maxX = Math.max(maxX, coord.x);
+                        maxY = Math.max(maxY, coord.y);
+                    }
+                    addGobToList(new Coord2d(minX, minY).floor(), new Coord2d(maxX, maxY).floor(), gob);
                 }
             }
         }

--- a/src/haven/automated/pathfinder/Pathfinder.java
+++ b/src/haven/automated/pathfinder/Pathfinder.java
@@ -84,27 +84,24 @@ public class Pathfinder implements Runnable {
                 if (this.gob != null && this.gob.id == gob.id) {
                     continue;
                 }
-                if (gob.getres() != null && isInsideBoundBox(gob.rc.floor(), gob.a, gob.getres().name, player.rc.floor())) {
-                    if (HitBoxes.collisionBoxMap.get(gob.getres().name) != null) {
-                        HitBoxes.CollisionBox[] collisionBoxes = HitBoxes.collisionBoxMap.get(gob.getres().name);
-                        for (HitBoxes.CollisionBox collisionBox : collisionBoxes) {
-                            if (collisionBox.hitAble) {
-                                if (collisionBox.coords.length > 2) {
-                                    double minX = Double.MAX_VALUE;
-                                    double minY = Double.MAX_VALUE;
-                                    double maxX = Double.MIN_VALUE;
-                                    double maxY = Double.MIN_VALUE;
+                if (gob.getres() != null && isInsideBoundBox(gob, player.rc.floor())) {
+                    for (HitBoxes.CollisionBox collisionBox : HitBoxes.getCollisionBoxes(gob)) {
+                        if (collisionBox.hitAble) {
+                            if (collisionBox.coords.length > 2) {
+                                double minX = Double.MAX_VALUE;
+                                double minY = Double.MAX_VALUE;
+                                double maxX = Double.MIN_VALUE;
+                                double maxY = Double.MIN_VALUE;
 
-                                    for (Coord2d coord : collisionBox.coords) {
-                                        minX = Math.min(minX, coord.x);
-                                        minY = Math.min(minY, coord.y);
-                                        maxX = Math.max(maxX, coord.x);
-                                        maxY = Math.max(maxY, coord.y);
-                                    }
-                                    Coord2d topLeft = new Coord2d(minX, minY);
-                                    Coord2d bottomRight = new Coord2d(maxX, maxY);
-                                    m.excludeGob(topLeft.floor(), bottomRight.floor(), gob);
+                                for (Coord2d coord : collisionBox.coords) {
+                                    minX = Math.min(minX, coord.x);
+                                    minY = Math.min(minY, coord.y);
+                                    maxX = Math.max(maxX, coord.x);
+                                    maxY = Math.max(maxY, coord.y);
                                 }
+                                Coord2d topLeft = new Coord2d(minX, minY);
+                                Coord2d bottomRight = new Coord2d(maxX, maxY);
+                                m.excludeGob(topLeft.floor(), bottomRight.floor(), gob);
                             }
                         }
                     }
@@ -141,30 +138,28 @@ public class Pathfinder implements Runnable {
         }
 
         // exclude any bounding boxes overlapping the destination gob
-        if (this.gob != null)
-            if (HitBoxes.collisionBoxMap.get(this.gob.getres().name) != null) {
-                HitBoxes.CollisionBox[] collisionBoxes = HitBoxes.collisionBoxMap.get(this.gob.getres().name);
-                for (HitBoxes.CollisionBox collisionBox : collisionBoxes) {
-                    if (collisionBox.hitAble) {
-                        if (collisionBox.coords.length > 2) {
-                            double minX = Double.MAX_VALUE;
-                            double minY = Double.MAX_VALUE;
-                            double maxX = Double.MIN_VALUE;
-                            double maxY = Double.MIN_VALUE;
+        if (this.gob != null) {
+            for (HitBoxes.CollisionBox collisionBox : HitBoxes.getCollisionBoxes(gob)) {
+                if (collisionBox.hitAble) {
+                    if (collisionBox.coords.length > 2) {
+                        double minX = Double.MAX_VALUE;
+                        double minY = Double.MAX_VALUE;
+                        double maxX = Double.MIN_VALUE;
+                        double maxY = Double.MIN_VALUE;
 
-                            for (Coord2d coord : collisionBox.coords) {
-                                minX = Math.min(minX, coord.x);
-                                minY = Math.min(minY, coord.y);
-                                maxX = Math.max(maxX, coord.x);
-                                maxY = Math.max(maxY, coord.y);
-                            }
-                            Coord2d topLeft = new Coord2d(minX, minY);
-                            Coord2d bottomRight = new Coord2d(maxX, maxY);
-                            m.excludeGob(topLeft.floor(), bottomRight.floor(), this.gob);
+                        for (Coord2d coord : collisionBox.coords) {
+                            minX = Math.min(minX, coord.x);
+                            minY = Math.min(minY, coord.y);
+                            maxX = Math.max(maxX, coord.x);
+                            maxY = Math.max(maxY, coord.y);
                         }
+                        Coord2d topLeft = new Coord2d(minX, minY);
+                        Coord2d bottomRight = new Coord2d(maxX, maxY);
+                        m.excludeGob(topLeft.floor(), bottomRight.floor(), this.gob);
                     }
                 }
             }
+        }
 
         if (Map.DEBUG_TIMINGS)
             System.out.println("      Gobs Processing: " + (double) (System.nanoTime() - start) / 1000000.0 + " ms.");
@@ -243,60 +238,59 @@ public class Pathfinder implements Runnable {
     }
 
 
-    public static boolean isInsideBoundBox(Coord gobRc, double gobA, String resName, Coord point) {
-        if (HitBoxes.collisionBoxMap.get(resName) != null) {
-            HitBoxes.CollisionBox[] collisionBoxes = HitBoxes.collisionBoxMap.get(resName);
-            for (HitBoxes.CollisionBox collisionBox : collisionBoxes) {
-                if (collisionBox.hitAble) {
-                    if (collisionBox.coords.length > 3) {
-                        double minX = Double.MAX_VALUE;
-                        double minY = Double.MAX_VALUE;
-                        double maxX = Double.MIN_VALUE;
-                        double maxY = Double.MIN_VALUE;
+    public static boolean isInsideBoundBox(Gob gob, Coord point) {
+        double gobA = gob.a;
+        Coord rc = gob.rc.floor();
+        for (HitBoxes.CollisionBox collisionBox : HitBoxes.getCollisionBoxes(gob)) {
+            if (collisionBox.hitAble) {
+                if (collisionBox.coords.length > 3) {
+                    double minX = Double.MAX_VALUE;
+                    double minY = Double.MAX_VALUE;
+                    double maxX = Double.MIN_VALUE;
+                    double maxY = Double.MIN_VALUE;
 
-                        for (Coord2d coord : collisionBox.coords) {
-                            minX = Math.min(minX, coord.x);
-                            minY = Math.min(minY, coord.y);
-                            maxX = Math.max(maxX, coord.x);
-                            maxY = Math.max(maxY, coord.y);
-                        }
-                        Coord2d topLeft = new Coord2d(minX, minY);
-                        Coord2d bottomRight = new Coord2d(maxX, maxY);
-
-                        final Coordf relative = new Coordf(point.sub(gobRc)).rotate(-gobA);
-                        if (relative.x >= topLeft.x && relative.x <= bottomRight.x &&
-                                relative.y >= topLeft.y && relative.y <= bottomRight.y) {
-                            return true;
-                        }
-
+                    for (Coord2d coord : collisionBox.coords) {
+                        minX = Math.min(minX, coord.x);
+                        minY = Math.min(minY, coord.y);
+                        maxX = Math.max(maxX, coord.x);
+                        maxY = Math.max(maxY, coord.y);
                     }
-                    if (collisionBox.coords.length == 3) {
-                        double minX = Double.MAX_VALUE;
-                        double minY = Double.MAX_VALUE;
-                        double maxX = Double.MIN_VALUE;
-                        double maxY = Double.MIN_VALUE;
+                    Coord2d topLeft = new Coord2d(minX, minY);
+                    Coord2d bottomRight = new Coord2d(maxX, maxY);
 
-                        for (Coord2d coord : collisionBox.coords) {
-                            if (coord.x < minX) {
-                                minX = coord.x;
-                            }
-                            if (coord.y < minY) {
-                                minY = coord.y;
-                            }
-                            if (coord.x > maxX) {
-                                maxX = coord.x;
-                            }
-                            if (coord.y > maxY) {
-                                maxY = coord.y;
-                            }
+                    final Coordf relative = new Coordf(point.sub(rc)).rotate(-gobA);
+                    if (relative.x >= topLeft.x && relative.x <= bottomRight.x &&
+                            relative.y >= topLeft.y && relative.y <= bottomRight.y) {
+                        return true;
+                    }
+
+                }
+                if (collisionBox.coords.length == 3) {
+                    double minX = Double.MAX_VALUE;
+                    double minY = Double.MAX_VALUE;
+                    double maxX = Double.MIN_VALUE;
+                    double maxY = Double.MIN_VALUE;
+
+                    for (Coord2d coord : collisionBox.coords) {
+                        if (coord.x < minX) {
+                            minX = coord.x;
                         }
-                        Coord2d topLeft = new Coord2d(minX, minY);
-                        Coord2d bottomRight = new Coord2d(maxX, maxY);
-                        final Coordf relative = new Coordf(point.sub(gobRc)).rotate(-gobA);
-                        if (relative.x >= topLeft.x && relative.x <= bottomRight.x &&
-                                relative.y >= topLeft.y && relative.y <= bottomRight.y) {
-                            return true;
+                        if (coord.y < minY) {
+                            minY = coord.y;
                         }
+                        if (coord.x > maxX) {
+                            maxX = coord.x;
+                        }
+                        if (coord.y > maxY) {
+                            maxY = coord.y;
+                        }
+                    }
+                    Coord2d topLeft = new Coord2d(minX, minY);
+                    Coord2d bottomRight = new Coord2d(maxX, maxY);
+                    final Coordf relative = new Coordf(point.sub(rc)).rotate(-gobA);
+                    if (relative.x >= topLeft.x && relative.x <= bottomRight.x &&
+                            relative.y >= topLeft.y && relative.y <= bottomRight.y) {
+                        return true;
                     }
                 }
             }


### PR DESCRIPTION
Currently, it appears that pathfinder only takes into account the hard-coded animals' hitboxes, but doesn't account for any other gobs, instead defaulting to no hitbox. This hooks up hitboxes to read from the Gob, and store to SQL tables defined in the class (though not read from them).