### PR TITLE
Fix to use apis available to java 15

### DIFF
--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -246,7 +246,7 @@ public class Inventory extends Widget implements DTarget {
 				.flatMap(w -> w.children().stream())
 				.filter(child -> child instanceof Inventory)
 				.map(i -> (Inventory) i)
-				.toList();
+				.collect(Collectors.toList());
 
 		List<Integer> externalInventoryIds = inventories
 				.stream()
@@ -261,7 +261,7 @@ public class Inventory extends Widget implements DTarget {
 				.map(i -> i.getchild(ISBox.class))
 				.filter(Objects::nonNull)
 				.map(Widget::wdgid)
-				.toList();
+				.collect(Collectors.toList());
 
 		externalInventoryIds.addAll(stockpileIds);
 		return externalInventoryIds;


### PR DESCRIPTION
Fixes https://www.havenandhearth.com/forum/viewtopic.php?f=49&t=76544&start=70#p955361 - my merged PR https://github.com/Nightdawg/Hurricane/pull/20 uses a Java 16 stream API convenience function `toList()`. With this, setting my language level to 15 in Intellij doesn't show any errors in the file.