### PR TITLE
Sort experience events by last seen instead of alphabetical;

### DIFF
--- a/src/haven/SkillWnd.java
+++ b/src/haven/SkillWnd.java
@@ -126,7 +126,6 @@ public class SkillWnd extends Widget {
     public class Experience {
 	public final Indir<Resource> res;
 	public final int mtime, score;
-	private String sortkey = "\uffff";
 	private Tex small;
 
 	private Experience(Indir<Resource> res, int mtime, int score) {
@@ -389,16 +388,8 @@ public class SkillWnd extends Widget {
 	    super.tick(dt);
 	    if(loading) {
 		loading = false;
-		for(Experience exp : seen.items) {
-		    try {
-			exp.sortkey = exp.res.get().flayer(Resource.tooltip).t;
-		    } catch(Loading l) {
-			exp.sortkey = "\uffff";
-			loading = true;
-		    }
-		}
-		Collections.sort(seen.items, (a, b) -> a.sortkey.compareTo(b.sortkey));
-	    }
+        Collections.sort(seen.items, Comparator.comparing((Experience a) -> a.mtime).reversed());
+        }
 	}
     }
 


### PR DESCRIPTION
Lore (Experience) Events are sorted alphabetically by default. This is not very useful when trying to figure out which Lore event is currently blocking other events. So sorting the events in the Lore screen by last seen is very useful to find which event your char has not seen from the longest time. 

I was using before ARD client and it had that feature. Took the idea to implement it from there. 
Tested locally.


[New Bitmap image.bmp](https://github.com/user-attachments/files/22101216/New.Bitmap.image.bmp)
