### PR TITLE
Only read 'gridRequests' from /gridUpdate response

### DIFF
--- a/src/haven/automated/mapper/MappingClient.java
+++ b/src/haven/automated/mapper/MappingClient.java
@@ -94,8 +94,6 @@ public class MappingClient {
 	    EnterGrid(gc);
 	}
     }
-    
-    private final Map<Long, MapRef> cache = new HashMap<Long, MapRef>();
 
     public void ProcessMap(MapFile mapfile, Predicate<MapFile.Marker> uploadCheck) {
 	scheduler.schedule(new ExtractMapper(mapfile, uploadCheck), 5, TimeUnit.SECONDS);
@@ -402,12 +400,9 @@ public class MappingClient {
 			    buffer.write(data, 0, nRead);
 			}
 			buffer.flush();
-			String response = buffer.toString(StandardCharsets.UTF_8.name());
+			String response = buffer.toString(StandardCharsets.UTF_8);
 			JSONObject jo = new JSONObject(response);
 			JSONArray reqs = jo.optJSONArray("gridRequests");
-			synchronized (cache) {
-			    cache.put(Long.valueOf(gridUpdate.grids[1][1]), new MapRef(jo.getLong("map"), new Coord(jo.getJSONObject("coords").getInt("x"), jo.getJSONObject("coords").getInt("y"))));
-			}
 			for (int i = 0; reqs != null && i < reqs.length(); i++) {
 			    gridsUploader.execute(new GridUploadTask(reqs.getString(i), gridUpdate.gridRefs.get(reqs.getString(i))));
 			}
@@ -467,20 +462,6 @@ public class MappingClient {
     private static Coord2d gridOffset(Coord2d c) {
 	Coord gridUnit = toGridUnit(c);
 	return new Coord2d(c.x - gridUnit.x, c.y - gridUnit.y);
-    }
-    
-    public class MapRef {
-	public Coord gc;
-	public long mapID;
-	
-	private MapRef(long mapID, Coord gc) {
-	    this.gc = gc;
-	    this.mapID = mapID;
-	}
-	
-	public String toString() {
-	    return (gc.toString() + " in map space " + mapID);
-	}
     }
 
 	public void uploadSMarker(Gob gob, MapFile.SMarker marker) {


### PR DESCRIPTION
Long long time ago, there used to be feature baked in the clients that allowed you to find yourself on the global, public map.
The mapper simply returned the map location in a form of (map id, x, y) and the client used it to create a link which would show you the grid you're on.

Hurricane doesn't have that feature, and probably won't since modern private maps track in a better way, but it still expects the mapper to return the map id, x, y in the response data. This is then stored on that `cache` HashMap never to be used again and this map grows over time as you travel the world.

So, I suggest removing it; mappers won't have to send that useless data back and client won't be storing that ever-growing map of grids.