### PR TITLE
Kami map client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /local-boot.properties
 /build.properties
 /.idea
+/.vscode
 *~

--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -1183,7 +1183,7 @@ public class Config {
 			MappingClient.destroy();
 		}
         if (!OptWnd.webmapEndpointTextEntry.text().isEmpty() && ui.sess != null && ui.sess.glob != null) {
-            MappingClient.init(ui.sess.glob);
+            MappingClient.init(ui.sess.glob, ui.sess.user.genus);
             MappingClient automapper = MappingClient.getInstance();
             if (automapper != null)
                 automapper.SetPlayerName(OptWnd.liveLocationNameTextEntry.buf.line() + " (" + playername + ")");

--- a/src/haven/GameUI.java
+++ b/src/haven/GameUI.java
@@ -581,6 +581,7 @@ public class GameUI extends ConsoleHost implements Console.Directory, UI.Notice.
 	@Override
 	protected void attach(UI ui) {
 		ui.setGUI(this);
+		ui.sess.user.genus = genus;
 		super.attach(ui);
 	}
 	@Override

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -4763,6 +4763,7 @@ public class OptWnd extends Window {
 	public static TextEntry webmapEndpointTextEntry;
 	public static CheckBox uploadMapTilesCheckBox;
 	public static CheckBox sendLiveLocationCheckBox;
+	public static CheckBox supplyGenusCheckBox;
 	public static TextEntry liveLocationNameTextEntry;
 //	public static TextEntry webmapTokenTextEntry;
 
@@ -4799,6 +4800,14 @@ public class OptWnd extends Window {
 				}
 			}, prev.pos("bl").adds(0, 12));
 			sendLiveLocationCheckBox.tooltip = sendLiveLocationTooltip;
+
+			prev = add(supplyGenusCheckBox = new CheckBox("Supply world genus"){
+				{a = Utils.getprefb("supplyGenus", true);}
+				public void changed(boolean val) {
+					Utils.setprefb("supplyGenus", val);
+				}
+			}, prev.pos("bl").adds(0, 12));
+			supplyGenusCheckBox.tooltip = supplyGenusTooltip;
 
 			prev = add(new Label("Your Live Location Name (Req. Relog):"), prev.pos("bl").adds(20, 4));
 			prev.tooltip = liveLocationNameTooltip;
@@ -5612,6 +5621,7 @@ public class OptWnd extends Window {
 	// Server Integration Settings Tooltips
 	private static final Object uploadMapTilesTooltip = RichText.render("Enable this to upload your map tiles to your web map server.", UI.scale(300));
 	private static final Object sendLiveLocationTooltip = RichText.render("Enable this to show your current location on your web map server.", UI.scale(320));
+	private static final Object supplyGenusTooltip = RichText.render("Enables compatibility with Kami's map service. Disable if it interferes with other mapping services.", UI.scale(320));
 	private static final Object liveLocationNameTooltip = RichText.render("If you send your location to the server, your name will appear as whatever you set in this text entry + your current character name." +
 			"\n" +
 			"\n$col[218,163,0]{For example:} Nightdawg (VillageCrafter)$col[185,185,185]{, where }\"Nightdawg\" $col[185,185,185]{is the name I set in this text entry, and} \"VillageCrafter\" $col[185,185,185]{is the character's original name." +

--- a/src/haven/Session.java
+++ b/src/haven/Session.java
@@ -69,7 +69,7 @@ public class Session implements Resource.Resolver {
 
     public static class User {
 	public final String name;
-	public String alias = null, readname = null, prsname = null;
+	public String alias = null, readname = null, prsname = null, genus = null;
 
 	public User(String name) {
 	    this.name = name;

--- a/src/haven/automated/mapper/MappingClient.java
+++ b/src/haven/automated/mapper/MappingClient.java
@@ -301,6 +301,7 @@ public class MappingClient {
 		spamCount = 0;
 		if(OptWnd.sendLiveLocationCheckBox.a) {
 		    Glob g = glob;
+		    boolean supplyGenus = OptWnd.supplyGenusCheckBox.a;
 		    Iterator<Map.Entry<Long, Tracking>> i = tracking.entrySet().iterator();
 		    JSONObject upload = new JSONObject();
 		    while (i.hasNext()) {
@@ -308,7 +309,6 @@ public class MappingClient {
 			if(g.oc.getgob(e.getKey()) == null) {
 			    i.remove();
 			} else {
-			    boolean supplyGenus = OptWnd.supplyGenusCheckBox.a;
 			    upload.put(String.valueOf(e.getKey()), e.getValue().getJSON(supplyGenus));
 			}
 		    }

--- a/src/haven/automated/mapper/MappingClient.java
+++ b/src/haven/automated/mapper/MappingClient.java
@@ -162,6 +162,7 @@ public class MappingClient {
 	    ArrayList<JSONObject> loadedMarkers = new ArrayList<>();
 	    while (!markers.isEmpty()) {
 		Iterator<MarkerData> iterator = markers.iterator();
+		String _genus = OptWnd.supplyGenusCheckBox.a ? genus : null;
 		while (iterator.hasNext()) {
 		    MarkerData md = iterator.next();
 		    try {
@@ -175,7 +176,7 @@ public class MappingClient {
 			}
 			JSONObject o = new JSONObject();
 			o.put("name", md.m.nm);
-			if(genus != null && OptWnd.supplyGenusCheckBox.a) {
+			if(_genus != null) {
 				o.put("genus", genus);
 			}
 			o.put("gridID", String.valueOf(gridId));

--- a/src/haven/automated/mapper/MappingClient.java
+++ b/src/haven/automated/mapper/MappingClient.java
@@ -29,11 +29,12 @@ public class MappingClient {
     private int spamPreventionVal = 3;
     private int spamCount = 0;
     private Glob glob;
+    private String genus;
     
-    public static void init(Glob glob) {
+    public static void init(Glob glob, String genus) {
 	synchronized (MappingClient.class) {
 	    if(INSTANCE == null) {
-		INSTANCE = new MappingClient(glob);
+		INSTANCE = new MappingClient(glob, genus);
 	    } else {
 		throw new IllegalStateException("MappingClient can only be initialized once!");
 	    }
@@ -63,8 +64,9 @@ public class MappingClient {
 
     private PositionUpdates pu = new PositionUpdates();
     
-    private MappingClient(Glob glob) {
+    private MappingClient(Glob glob, String genus) {
 	this.glob = glob;
+	this.genus = genus;
 	scheduler.scheduleAtFixedRate(pu, 2L, 2L, TimeUnit.SECONDS);
     }
 
@@ -77,7 +79,7 @@ public class MappingClient {
     public void Track(long id, Coord2d coordinates) {
 	try {
 	    MCache.Grid g = glob.map.getgrid(toGC(coordinates));
-	    pu.Track(id, coordinates, g.id);
+	    pu.Track(id, coordinates, g.id, genus);
 	} catch (Exception ex) {}
     }
     
@@ -85,7 +87,8 @@ public class MappingClient {
 
     public void EnterGrid(Coord gc) {
 	lastGC = gc;
-	scheduler.execute(new GenerateGridUpdateTask(gc));
+	String _genus = OptWnd.supplyGenusCheckBox.a ? this.genus : null;
+	scheduler.execute(new GenerateGridUpdateTask(gc, _genus));
     }
 
     public void CheckGridCoord(Coord2d c) {
@@ -172,6 +175,9 @@ public class MappingClient {
 			}
 			JSONObject o = new JSONObject();
 			o.put("name", md.m.nm);
+			if(genus != null && OptWnd.supplyGenusCheckBox.a) {
+				o.put("genus", genus);
+			}
 			o.put("gridID", String.valueOf(gridId));
 			Coord gridOffset = md.m.tc.sub(mgc.mul(100));
 			o.put("x", gridOffset.x);
@@ -231,13 +237,17 @@ public class MappingClient {
     private class PositionUpdates implements Runnable {
 	private class Tracking {
 	    public String name;
+			public String genus;
 	    public String type;
 	    public long gridId;
 	    public Coord2d coords;
 	    
-	    public JSONObject getJSON() {
+	    public JSONObject getJSON(boolean supplyGenus) {
 		JSONObject j = new JSONObject();
 		j.put("name", name);
+		if(supplyGenus && genus != null) {
+			j.put("genus", genus);
+		}
 		j.put("type", type);
 		j.put("gridID", String.valueOf(gridId));
 		JSONObject c = new JSONObject();
@@ -246,6 +256,9 @@ public class MappingClient {
 		j.put("coords", c);
 		return j;
 	    }
+		public JSONObject getJSON() {
+			return getJSON(false);
+		}
 	}
 	
 	private Map<Long, Tracking> tracking = new ConcurrentHashMap<Long, Tracking>();
@@ -253,7 +266,7 @@ public class MappingClient {
 	private PositionUpdates() {
 	}
 	
-	private void Track(long id, Coord2d coordinates, long gridId) {
+	private void Track(long id, Coord2d coordinates, long gridId, String genus) {
 	    Tracking t = tracking.get(id);
 	    if(t == null) {
 		t = new Tracking();
@@ -276,6 +289,7 @@ public class MappingClient {
 		    }
 		}
 	    }
+	    t.genus = genus;
 	    t.gridId = gridId;
 	    t.coords = gridOffset(coordinates);
 	}
@@ -293,7 +307,8 @@ public class MappingClient {
 			if(g.oc.getgob(e.getKey()) == null) {
 			    i.remove();
 			} else {
-			    upload.put(String.valueOf(e.getKey()), e.getValue().getJSON());
+			    boolean supplyGenus = OptWnd.supplyGenusCheckBox.a;
+			    upload.put(String.valueOf(e.getKey()), e.getValue().getJSON(supplyGenus));
 			}
 		    }
 		    
@@ -335,10 +350,12 @@ public class MappingClient {
     
     private class GenerateGridUpdateTask implements Runnable {
 	Coord coord;
+	String genus;
 	int retries = 3;
 	
-	GenerateGridUpdateTask(Coord c) {
+	GenerateGridUpdateTask(Coord c, String genus) {
 	    this.coord = c;
+	    this.genus = genus;
 	}
 	
 	@Override
@@ -354,7 +371,7 @@ public class MappingClient {
 			    gridRefs.put(String.valueOf(subg.id), new WeakReference<MCache.Grid>(subg));
 			}
 		    }
-		    scheduler.execute(new UploadGridUpdateTask(new GridUpdate(gridMap, gridRefs)));
+		    scheduler.execute(new UploadGridUpdateTask(new GridUpdate(gridMap, gridRefs), genus));
 		} catch (LoadingMap lm) {
 		    retries--;
 		    if(retries >= 0) {
@@ -370,9 +387,10 @@ public class MappingClient {
     
     private class UploadGridUpdateTask implements Runnable {
 	private final GridUpdate gridUpdate;
-	
-	UploadGridUpdateTask(final GridUpdate gridUpdate) {
+	String genus;
+	UploadGridUpdateTask(final GridUpdate gridUpdate, String genus) {
 	    this.gridUpdate = gridUpdate;
+	    this.genus = genus;
 	}
 	
 	@Override
@@ -381,6 +399,9 @@ public class MappingClient {
 		HashMap<String, Object> dataToSend = new HashMap<>();
 		
 		dataToSend.put("grids", this.gridUpdate.grids);
+		if (this.genus != null) {
+			dataToSend.put("genus", this.genus);
+		}
 		try {
 		    HttpURLConnection connection =
 			(HttpURLConnection) new URL(OptWnd.webmapEndpointTextEntry.buf.line() + "/gridUpdate").openConnection();
@@ -403,8 +424,10 @@ public class MappingClient {
 			String response = buffer.toString(StandardCharsets.UTF_8);
 			JSONObject jo = new JSONObject(response);
 			JSONArray reqs = jo.optJSONArray("gridRequests");
+			String _genus = OptWnd.supplyGenusCheckBox.a ? this.genus : null;
 			for (int i = 0; reqs != null && i < reqs.length(); i++) {
-			    gridsUploader.execute(new GridUploadTask(reqs.getString(i), gridUpdate.gridRefs.get(reqs.getString(i))));
+			    gridsUploader.execute(
+						new GridUploadTask(reqs.getString(i), gridUpdate.gridRefs.get(reqs.getString(i)), _genus));
 			}
 		    }
 		    
@@ -416,10 +439,11 @@ public class MappingClient {
     private class GridUploadTask implements Runnable {
 	private final String gridID;
 	private final WeakReference<MCache.Grid> grid;
-	
-	GridUploadTask(String gridID, WeakReference<MCache.Grid> grid) {
+	private final String genus;
+	GridUploadTask(String gridID, WeakReference<MCache.Grid> grid, String genus) {
 	    this.gridID = gridID;
 	    this.grid = grid;
+	    this.genus = genus;
 	}
 	
 	@Override
@@ -438,6 +462,9 @@ public class MappingClient {
 			ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
 			MultipartUtility multipart = new MultipartUtility(OptWnd.webmapEndpointTextEntry.buf.line() + "/gridUpload", "utf-8");
 			multipart.addFormField("id", this.gridID);
+			if(this.genus != null) {
+				multipart.addFormField("genus", this.genus);
+			}
 			multipart.addFilePart("file", inputStream, "minimap.png");
 			extraData.put("season", glob.ast.is);
 			multipart.addFormField("extraData", extraData.toString());
@@ -471,6 +498,9 @@ public class MappingClient {
 
 			JSONObject obj = new JSONObject();
 			obj.put("name", marker.nm);
+			if(genus != null && OptWnd.supplyGenusCheckBox.a) {
+				obj.put("genus", genus);
+			}
 			obj.put("gridID", String.valueOf(grid.id));
 			obj.put("x", offset.x);
 			obj.put("y", offset.y);


### PR DESCRIPTION
This PR enables map upload and tracking compatibility with Kami's mapping service.
1. Added genus field to MappingClient to determine current world
2. Added a checkbox to options that enables/disables usage of genus in the API. Enabled by default, can be disabled just in case some mapping service implementation I am not aware of will break from additional data. Tell me if I need to remove this.
3. Added a genus field to user session so I can pass it to MappingClient. There is already genus stored in GameUI for use with cookbook and to perform checks for logic that differs between worlds (like gates behavior). GameUI doesn't exist at a time when MappingClient is initialized, so I couldn't use this field. I decided to keep both fields in for convenience.