### PR TITLE
Sort inventories from a validated move plan, and add a column-fill mode

### DIFF
--- a/src/haven/Window.java
+++ b/src/haven/Window.java
@@ -477,15 +477,16 @@ public class Window extends Widget {
 			return;
 
         sortbtn = add(new IButton(sortbtni[0], sortbtni[1], sortbtni[2])).action(() -> {
+            boolean vertical = (ui.modflags() & UI.MOD_SHIFT) != 0;
             for (Widget wdg = this; wdg != null; wdg = wdg.next) {
                 Inventory inv = Inventory.fromWidget(wdg);
                 if (inv != null) {
-                    InventorySorter.sort(inv);
+                    InventorySorter.sort(inv, vertical);
                     break;
                 }
             }
         });
-        sortbtn.settip("Sort All");
+        sortbtn.settip("Sort (Shift+Click: fill columns)");
         sortbtn.visible = false;
         refreshInventoryButtons();
     }

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -75,8 +75,20 @@ class InventoryLayout {
      */
     static Coord[] assignTargets(boolean[][] mask, Coord isz, Coord[] slots,
 				 Coord[] current, boolean vertical) {
+	return assignTargets(mask, isz, slots, current, vertical, new boolean[slots.length]);
+    }
+
+    /**
+     * As above, with items the caller has already given up on. Used by
+     * InventoryMoves: an item can fit its target and still be impossible to
+     * carry there, and only the move planner knows which.
+     *
+     * `seed` is not modified.
+     */
+    static Coord[] assignTargets(boolean[][] mask, Coord isz, Coord[] slots,
+				 Coord[] current, boolean vertical, boolean[] seed) {
 	Coord[] targets = new Coord[slots.length];
-	boolean[] pinned = new boolean[slots.length];
+	boolean[] pinned = Arrays.copyOf(seed, seed.length);
 	int[] order = packOrder(slots, vertical);
 	for (int attempt = 0; attempt <= slots.length; attempt++) {
 	    boolean[][] grid = copyGrid(mask, isz);

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -53,9 +53,10 @@ class InventoryLayout {
     }
 
     /**
-     * Marks an item's rect, ignoring cells outside isz. Used for positions
-     * reported by the server, which markGrid's unchecked indexing cannot accept.
-     * The caller is responsible for isz matching the grid's actual dimensions.
+     * Marks an item's rect, ignoring cells outside isz. For positions that are not
+     * findFit results - widget geometry or server echoes - which markGrid's
+     * unchecked indexing cannot accept. The caller is responsible for isz matching
+     * the grid's actual dimensions.
      */
     static void markOccupied(boolean[][] grid, Coord isz, Coord pos, Coord slots, boolean val) {
 	for (int x = pos.x; x < pos.x + slots.x; x++)

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -31,6 +31,73 @@ class InventoryLayout {
 	return null;
     }
 
+    /**
+     * Order to pack items in: largest first, ties broken along the fill
+     * direction, then by display order. Placing the big items while the grid is
+     * still whole is what keeps first-fit from splitting the free space into
+     * pieces too small for them - packing in display order does not, and can
+     * fail to re-home an item set that demonstrably fits.
+     *
+     * Returns indices into slots. Stable, so items of one size keep their
+     * display order relative to each other.
+     */
+    static int[] packOrder(Coord[] slots, boolean vertical) {
+	Integer[] order = new Integer[slots.length];
+	for (int i = 0; i < order.length; i++)
+	    order[i] = i;
+	Arrays.sort(order, (a, b) -> {
+	    Coord sa = slots[a], sb = slots[b];
+	    int c = (sb.x * sb.y) - (sa.x * sa.y);
+	    if (c != 0) return c;
+	    // along the fill direction first: a vertical sort cares about height
+	    c = vertical ? (sb.y - sa.y) : (sb.x - sa.x);
+	    if (c != 0) return c;
+	    c = vertical ? (sb.x - sa.x) : (sb.y - sa.y);
+	    if (c != 0) return c;
+	    return a - b;
+	});
+	int[] out = new int[order.length];
+	for (int i = 0; i < out.length; i++)
+	    out[i] = order[i];
+	return out;
+    }
+
+    /**
+     * Target position for every item, packed largest-first but returned aligned
+     * to the caller's display order. Null means the item did not fit anywhere
+     * and is pinned where it already is.
+     *
+     * An item that does not fit is pinned rather than skipped: its current rect
+     * is reserved and the pass restarts, so no other item is ever assigned a
+     * target on top of it. That terminates - each restart pins one more item,
+     * and the all-pinned state is the original layout, which fits by
+     * construction.
+     */
+    static Coord[] assignTargets(boolean[][] mask, Coord isz, Coord[] slots,
+				 Coord[] current, boolean vertical) {
+	Coord[] targets = new Coord[slots.length];
+	boolean[] pinned = new boolean[slots.length];
+	int[] order = packOrder(slots, vertical);
+	for (int attempt = 0; attempt <= slots.length; attempt++) {
+	    boolean[][] grid = copyGrid(mask, isz);
+	    for (int i = 0; i < slots.length; i++)
+		if (pinned[i])
+		    markOccupied(grid, isz, current[i], slots[i], true);
+	    Arrays.fill(targets, null);
+	    int failed = -1;
+	    for (int idx : order) {
+		if (pinned[idx]) continue;
+		Coord pos = findFit(grid, isz, slots[idx], vertical);
+		if (pos == null) { failed = idx; break; }
+		targets[idx] = pos;
+		markGrid(grid, pos, slots[idx], true);
+	    }
+	    if (failed < 0) return targets;
+	    pinned[failed] = true;
+	}
+	return targets;
+    }
+
     static boolean fits(boolean[][] grid, int ox, int oy, Coord slots) {
 	for (int x = 0; x < slots.x; x++)
 	    for (int y = 0; y < slots.y; y++)

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -52,6 +52,17 @@ class InventoryLayout {
 		grid[pos.x + x][pos.y + y] = val;
     }
 
+    /**
+     * Marks an item's rect, ignoring cells outside the grid. Used for positions
+     * reported by the server, which markGrid's unchecked indexing cannot accept.
+     */
+    static void markOccupied(boolean[][] grid, Coord isz, Coord pos, Coord slots, boolean val) {
+	for (int x = pos.x; x < pos.x + slots.x; x++)
+	    for (int y = pos.y; y < pos.y + slots.y; y++)
+		if (x >= 0 && x < isz.x && y >= 0 && y < isz.y)
+		    grid[x][y] = val;
+    }
+
     /** First free, unmasked cell in row-major scan order, or null. */
     static Coord findFreeCell(Coord isz, boolean[][] mask, boolean[][] occupied) {
 	for (int y = 0; y < isz.y; y++)

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -145,14 +145,4 @@ class InventoryLayout {
 		    grid[x][y] = val;
     }
 
-    /** First free, unmasked cell in row-major scan order, or null. */
-    static Coord findFreeCell(Coord isz, boolean[][] mask, boolean[][] occupied) {
-	for (int y = 0; y < isz.y; y++)
-	    for (int x = 0; x < isz.x; x++) {
-		if (mask[x][y]) continue;
-		if (occupied[x][y]) continue;
-		return new Coord(x, y);
-	    }
-	return null;
-    }
 }

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -51,4 +51,15 @@ class InventoryLayout {
 	    for (int y = 0; y < slots.y; y++)
 		grid[pos.x + x][pos.y + y] = val;
     }
+
+    /** First free, unmasked cell in row-major scan order, or null. */
+    static Coord findFreeCell(Coord isz, boolean[][] mask, boolean[][] occupied) {
+	for (int y = 0; y < isz.y; y++)
+	    for (int x = 0; x < isz.x; x++) {
+		if (mask[x][y]) continue;
+		if (occupied[x][y]) continue;
+		return new Coord(x, y);
+	    }
+	return null;
+    }
 }

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -53,8 +53,9 @@ class InventoryLayout {
     }
 
     /**
-     * Marks an item's rect, ignoring cells outside the grid. Used for positions
+     * Marks an item's rect, ignoring cells outside isz. Used for positions
      * reported by the server, which markGrid's unchecked indexing cannot accept.
+     * The caller is responsible for isz matching the grid's actual dimensions.
      */
     static void markOccupied(boolean[][] grid, Coord isz, Coord pos, Coord slots, boolean val) {
 	for (int x = pos.x; x < pos.x + slots.x; x++)

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -83,12 +83,13 @@ class InventoryLayout {
      * InventoryMoves: an item can fit its target and still be impossible to
      * carry there, and only the move planner knows which.
      *
-     * `seed` is not modified.
+     * `seed` is indexed like `slots` and is not modified; entries past its end
+     * count as unpinned.
      */
     static Coord[] assignTargets(boolean[][] mask, Coord isz, Coord[] slots,
 				 Coord[] current, boolean vertical, boolean[] seed) {
 	Coord[] targets = new Coord[slots.length];
-	boolean[] pinned = Arrays.copyOf(seed, seed.length);
+	boolean[] pinned = Arrays.copyOf(seed, slots.length);
 	int[] order = packOrder(slots, vertical);
 	for (int attempt = 0; attempt <= slots.length; attempt++) {
 	    boolean[][] grid = copyGrid(mask, isz);

--- a/src/haven/automated/InventoryLayout.java
+++ b/src/haven/automated/InventoryLayout.java
@@ -1,0 +1,54 @@
+package haven.automated;
+
+import haven.Coord;
+
+import java.util.Arrays;
+
+/**
+ * Pure grid placement logic for InventorySorter.
+ *
+ * Depends on nothing but haven.Coord on purpose: InventorySorter's static
+ * initialiser loads a sound from the resource server, so anything that needs
+ * to be testable has to live outside that class.
+ *
+ * Grids are boolean[x][y], true meaning unavailable.
+ */
+class InventoryLayout {
+    /**
+     * First position where an item of `slots` size fits, or null.
+     * Horizontal scans rows first, vertical scans columns first.
+     */
+    static Coord findFit(boolean[][] grid, Coord isz, Coord slots, boolean vertical) {
+	if (vertical) {
+	    for (int x = 0; x <= isz.x - slots.x; x++)
+		for (int y = 0; y <= isz.y - slots.y; y++)
+		    if (fits(grid, x, y, slots)) return new Coord(x, y);
+	} else {
+	    for (int y = 0; y <= isz.y - slots.y; y++)
+		for (int x = 0; x <= isz.x - slots.x; x++)
+		    if (fits(grid, x, y, slots)) return new Coord(x, y);
+	}
+	return null;
+    }
+
+    static boolean fits(boolean[][] grid, int ox, int oy, Coord slots) {
+	for (int x = 0; x < slots.x; x++)
+	    for (int y = 0; y < slots.y; y++)
+		if (grid[ox + x][oy + y]) return false;
+	return true;
+    }
+
+    static boolean[][] copyGrid(boolean[][] src, Coord sz) {
+	boolean[][] copy = new boolean[sz.x][sz.y];
+	for (int x = 0; x < sz.x; x++)
+	    copy[x] = Arrays.copyOf(src[x], sz.y);
+	return copy;
+    }
+
+    /** Marks an item's rect. The caller guarantees it is in bounds (a findFit result). */
+    static void markGrid(boolean[][] grid, Coord pos, Coord slots, boolean val) {
+	for (int x = 0; x < slots.x; x++)
+	    for (int y = 0; y < slots.y; y++)
+		grid[pos.x + x][pos.y + y] = val;
+    }
+}

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -49,6 +49,17 @@ public class InventoryLayoutTest {
 	check("7b findFit vertical, second 1x1", new Coord(0, 1),
 	      InventoryLayout.findFit(g7, isz43, one, true));
 
+	// 7c/7d: the whole point of the feature - walk column 0 to its end, then
+	// start column 1. A row-major scan gives (2,0) and (3,0) here instead.
+	boolean[][] g7c = grid(4, 3);
+	Coord[] seq = new Coord[4];
+	for (int i = 0; i < seq.length; i++) {
+	    seq[i] = InventoryLayout.findFit(g7c, isz43, one, true);
+	    InventoryLayout.markGrid(g7c, seq[i], one, true);
+	}
+	check("7c findFit vertical, third 1x1 ends column 0", new Coord(0, 2), seq[2]);
+	check("7d findFit vertical, fourth 1x1 starts column 1", new Coord(1, 0), seq[3]);
+
 	// 8: a 1x2 in a 3-row grid leaves one dead row in its column
 	Coord tall = new Coord(1, 2);
 	boolean[][] g8 = grid(4, 3);

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -112,12 +112,20 @@ public class InventoryLayoutTest {
 	// 5: genuinely full
 	check("5 findFreeCell, 2x2 full", null,
 	      InventoryLayout.findFreeCell(isz22, grid(2, 2), grid(2, 2, 0,0, 1,0, 0,1, 1,1)));
+
+	// 5b: only the far corner is free - an off-by-one that under-scans the
+	// last row or column would return null here, same as case 5 does
+	check("5b findFreeCell, only the last cell free", new Coord(3, 2),
+	      InventoryLayout.findFreeCell(isz43, grid(4, 3),
+					   grid(4, 3, 0,0, 1,0, 2,0, 3,0,
+						      0,1, 1,1, 2,1, 3,1,
+						      0,2, 1,2, 2,2)));
     }
 
     public static void main(String[] args) {
+	findFreeCellTests();
 	findFitTests();
 	copyGridTests();
-	findFreeCellTests();
 	System.out.println();
 	System.out.println(failures == 0
 			   ? (total + " of " + total + " passed")

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -233,11 +233,11 @@ public class InventoryLayoutTest {
 	check("23c assignTargets, two 1x2 and eight 1x1 all fit a 4x3", Boolean.TRUE,
 	      allPlaced(t23));
 
-	// 24: um item fixado de fora fica onde está, e nada é mandado por cima
-	// dele. É o gancho que o planejador de movimentos usa quando descobre
-	// que um item até cabe no alvo, mas não há como levá-lo até lá.
+	// 24: a caller-pinned item stays where it is, and nothing is sent on
+	// top of it. This is the hook the move planner uses once it finds that
+	// an item would fit its target but there is no way to get it there.
 	Coord[] sl24 = coords(cat(rep(1, 2, 1), rep(10, 1, 1)));
-	Coord[] cur24 = coords(2,2,                                  // o 2x1 ocupa (2,2)-(3,2)
+	Coord[] cur24 = coords(2,2,                                  // the 2x1 spans (2,2)-(3,2)
 			       0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 3,1, 0,2, 1,2);
 	boolean[] pin24 = new boolean[sl24.length];
 	pin24[0] = true;

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -93,6 +93,147 @@ public class InventoryLayoutTest {
 	      InventoryLayout.findFit(grid(2, 2), new Coord(2, 2), new Coord(3, 3), true));
     }
 
+    /** Coord list from flat (x,y) pairs - used for both sizes and positions. */
+    private static Coord[] coords(int... xy) {
+	Coord[] s = new Coord[xy.length / 2];
+	for (int i = 0; i < s.length; i++)
+	    s[i] = new Coord(xy[i * 2], xy[i * 2 + 1]);
+	return s;
+    }
+
+    /** n items of w*h, appended to the list being built. */
+    private static int[] rep(int n, int w, int h) {
+	int[] out = new int[n * 2];
+	for (int i = 0; i < n; i++) { out[i * 2] = w; out[i * 2 + 1] = h; }
+	return out;
+    }
+
+    private static int[] cat(int[]... parts) {
+	int len = 0;
+	for (int[] p : parts) len += p.length;
+	int[] out = new int[len];
+	int o = 0;
+	for (int[] p : parts) { System.arraycopy(p, 0, out, o, p.length); o += p.length; }
+	return out;
+    }
+
+    /** Every item got a target. */
+    private static boolean allPlaced(Coord[] targets) {
+	for (Coord t : targets)
+	    if (t == null) return false;
+	return true;
+    }
+
+    private static int placed(Coord[] targets) {
+	int n = 0;
+	for (Coord t : targets)
+	    if (t != null) n++;
+	return n;
+    }
+
+    /**
+     * The invariant every sort must hold: with unplaced items staying where
+     * they are, no two item rects may share a cell. A violation means the
+     * sorter will drop an item onto a cell another item still occupies.
+     */
+    private static boolean noOverlap(Coord[] targets, Coord[] current, Coord[] slots, Coord isz) {
+	int[][] count = new int[isz.x][isz.y];
+	for (int i = 0; i < slots.length; i++) {
+	    Coord at = targets[i] != null ? targets[i] : current[i];
+	    for (int x = at.x; x < at.x + slots[i].x; x++)
+		for (int y = at.y; y < at.y + slots[i].y; y++) {
+		    if (x < 0 || x >= isz.x || y < 0 || y >= isz.y) return false;
+		    if (++count[x][y] > 1) return false;
+		}
+	}
+	return true;
+    }
+
+    private static void assignTargetsTests() {
+	Coord isz43 = new Coord(4, 3);
+	Coord isz24 = new Coord(2, 4);
+
+	// 17: sanity - twelve 1x1 fill a 4x3 exactly, in both modes
+	Coord[] sl17 = coords(rep(12, 1, 1));
+	Coord[] cur17 = coords(0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 3,1, 0,2, 1,2, 2,2, 3,2);
+	check("17a assignTargets horizontal, twelve 1x1 in 4x3", Boolean.TRUE,
+	      allPlaced(InventoryLayout.assignTargets(grid(4, 3), isz43, sl17, cur17, false)));
+	check("17b assignTargets vertical, twelve 1x1 in 4x3", Boolean.TRUE,
+	      allPlaced(InventoryLayout.assignTargets(grid(4, 3), isz43, sl17, cur17, true)));
+
+	// 18: a full 4x3 holding ten 1x1 and one 1x2. The pre-sort layout is proof
+	// the set fits; sorting must not turn that into "no room". The 1x2 sorts
+	// last by name, so packing in display order scatters the 1x1 across both
+	// free cells first and leaves the 1x2 homeless.
+	Coord[] sl18 = coords(cat(rep(10, 1, 1), rep(1, 1, 2)));
+	Coord[] cur18 = coords(0,0, 1,0, 2,0, 0,1, 1,1, 2,1, 0,2, 1,2, 2,2, 3,2,
+			       3,0);   // the 1x2 spans (3,0)-(3,1)
+	Coord[] t18 = InventoryLayout.assignTargets(grid(4, 3), isz43, sl18, cur18, false);
+	check("18a assignTargets horizontal, 1x2 after ten 1x1 in a full 4x3", Boolean.TRUE,
+	      allPlaced(t18));
+	check("18b assignTargets horizontal, the full 4x3 stays consistent", Boolean.TRUE,
+	      noOverlap(t18, cur18, sl18, isz43));
+
+	// 19: the vertical counterpart - a 2x1 after five 1x1 in a 2x4
+	Coord[] sl19 = coords(cat(rep(5, 1, 1), rep(1, 2, 1)));
+	Coord[] cur19 = coords(0,0, 1,0, 0,1, 1,1, 0,2,
+			       0,3);   // the 2x1 spans (0,3)-(1,3)
+	Coord[] t19 = InventoryLayout.assignTargets(grid(2, 4), isz24, sl19, cur19, true);
+	check("19a assignTargets vertical, 2x1 after five 1x1 in a 2x4", Boolean.TRUE,
+	      allPlaced(t19));
+	check("19b assignTargets vertical, the 2x4 stays consistent", Boolean.TRUE,
+	      noOverlap(t19, cur19, sl19, isz24));
+
+	// 20: an item that genuinely cannot be re-homed. sqmask comes from the
+	// server, so it need not match where the items already sit: row 1 is
+	// masked while a 1x3 still spans (0,0)-(0,2). No column has three free
+	// rows, so the 1x3 has to stay put - and that must cost nothing else.
+	// It sits mid-list on purpose: at the end, aborting would cost nothing
+	// and the assertion below would pass for the wrong reason.
+	boolean[][] m20 = grid(4, 3, 0,1, 1,1, 2,1, 3,1);
+	Coord[] sl20 = coords(cat(rep(3, 1, 1), rep(1, 1, 3), rep(3, 1, 1)));
+	Coord[] cur20 = coords(1,0, 2,0, 3,0,
+			       0,0,               // the 1x3 spans (0,0)-(0,2)
+			       1,2, 2,2, 3,2);
+	Coord[] t20 = InventoryLayout.assignTargets(m20, isz43, sl20, cur20, false);
+	check("20a assignTargets pins the item that cannot be re-homed", null, t20[3]);
+	check("20b assignTargets, a misfit does not strand the items after it", 6,
+	      placed(t20));
+	check("20c assignTargets, no target lands on the pinned item", Boolean.TRUE,
+	      noOverlap(t20, cur20, sl20, isz43));
+
+	// 21: no two rects may overlap once pinned items are left in place
+	Coord[] sl21 = coords(cat(rep(10, 1, 1), rep(1, 1, 2)));
+	Coord[] cur21 = coords(0,0, 1,0, 2,0, 0,1, 1,1, 2,1, 0,2, 1,2, 2,2, 3,2, 3,0);
+	Coord[] t21 = InventoryLayout.assignTargets(grid(4, 3), isz43, sl21, cur21, false);
+	check("21 assignTargets, targets never overlap a pinned item", Boolean.TRUE,
+	      noOverlap(t21, cur21, sl21, isz43));
+
+	// 22: masked cells are honoured - a 4x3 with column 0 masked holds a 1x2
+	boolean[][] m22 = grid(4, 3, 0,0, 0,1, 0,2);
+	Coord[] sl22 = coords(cat(rep(4, 1, 1), rep(1, 1, 2)));
+	Coord[] cur22 = coords(1,0, 2,0, 3,0, 1,1,
+			       2,1);   // the 1x2 spans (2,1)-(2,2)
+	Coord[] t22 = InventoryLayout.assignTargets(m22, isz43, sl22, cur22, false);
+	check("22a assignTargets respects the mask", Boolean.TRUE, allPlaced(t22));
+	for (Coord t : t22)
+	    if (t != null && t.x == 0)
+		check("22b assignTargets placed an item in the masked column",
+		      "no target in column 0", t);
+
+	// 23: packing largest-first must not reshuffle items of the same size.
+	// Two 1x2 in display order A then B: A takes the earlier scan position.
+	Coord[] sl23 = coords(cat(rep(2, 1, 2), rep(8, 1, 1)));
+	Coord[] cur23 = coords(0,0, 1,0, 2,0, 3,0, 2,1, 3,1, 0,2, 1,2, 2,2, 3,2);
+	Coord[] t23 = InventoryLayout.assignTargets(grid(4, 3), isz43, sl23, cur23, false);
+	check("23a assignTargets, same-size items keep display order (first)", new Coord(0, 0),
+	      t23[0]);
+	check("23b assignTargets, same-size items keep display order (second)", new Coord(1, 0),
+	      t23[1]);
+	check("23c assignTargets, two 1x2 and eight 1x1 all fit a 4x3", Boolean.TRUE,
+	      allPlaced(t23));
+    }
+
     private static void copyGridTests() {
 	boolean[][] src = grid(4, 3, 1, 1);
 	boolean[][] copy = InventoryLayout.copyGrid(src, new Coord(4, 3));
@@ -163,6 +304,7 @@ public class InventoryLayoutTest {
     public static void main(String[] args) {
 	findFreeCellTests();
 	findFitTests();
+	assignTargetsTests();
 	copyGridTests();
 	markOccupiedTests();
 	System.out.println();

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -255,39 +255,6 @@ public class InventoryLayoutTest {
 	check("13 copyGrid does not alias the source", Boolean.FALSE, src[0][0]);
     }
 
-    private static void findFreeCellTests() {
-	Coord isz43 = new Coord(4, 3);
-	Coord isz22 = new Coord(2, 2);
-
-	// 1: column 0 full - what a vertical sort leaves behind. 8 cells free.
-	check("1 findFreeCell, column 0 full", new Coord(1, 0),
-	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 0,0, 0,1, 0,2)));
-
-	// 2: row 0 full - what a horizontal sort leaves behind. 8 cells free.
-	check("2 findFreeCell, row 0 full", new Coord(0, 1),
-	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 0,0, 1,0, 2,0, 3,0)));
-
-	// 3: scan stops before the occupied cell
-	check("3 findFreeCell, only (1,0) occupied", new Coord(0, 0),
-	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 1,0)));
-
-	// 4: a masked cell is skipped, not treated as scan-terminating
-	check("4 findFreeCell, masked (0,0) and occupied (1,0)", new Coord(2, 0),
-	      InventoryLayout.findFreeCell(isz43, grid(4, 3, 0,0), grid(4, 3, 1,0)));
-
-	// 5: genuinely full
-	check("5 findFreeCell, 2x2 full", null,
-	      InventoryLayout.findFreeCell(isz22, grid(2, 2), grid(2, 2, 0,0, 1,0, 0,1, 1,1)));
-
-	// 5b: only the far corner is free - an off-by-one that under-scans the
-	// last row or column would return null here, same as case 5 does
-	check("5b findFreeCell, only the last cell free", new Coord(3, 2),
-	      InventoryLayout.findFreeCell(isz43, grid(4, 3),
-					   grid(4, 3, 0,0, 1,0, 2,0, 3,0,
-						      0,1, 1,1, 2,1, 3,1,
-						      0,2, 1,2, 2,2)));
-    }
-
     private static void markOccupiedTests() {
 	Coord isz43 = new Coord(4, 3);
 
@@ -316,7 +283,6 @@ public class InventoryLayoutTest {
     }
 
     public static void main(String[] args) {
-	findFreeCellTests();
 	findFitTests();
 	assignTargetsTests();
 	copyGridTests();

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -89,9 +89,35 @@ public class InventoryLayoutTest {
 	check("13 copyGrid does not alias the source", Boolean.FALSE, src[0][0]);
     }
 
+    private static void findFreeCellTests() {
+	Coord isz43 = new Coord(4, 3);
+	Coord isz22 = new Coord(2, 2);
+
+	// 1: column 0 full - what a vertical sort leaves behind. 8 cells free.
+	check("1 findFreeCell, column 0 full", new Coord(1, 0),
+	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 0,0, 0,1, 0,2)));
+
+	// 2: row 0 full - what a horizontal sort leaves behind. 8 cells free.
+	check("2 findFreeCell, row 0 full", new Coord(0, 1),
+	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 0,0, 1,0, 2,0, 3,0)));
+
+	// 3: scan stops before the occupied cell
+	check("3 findFreeCell, only (1,0) occupied", new Coord(0, 0),
+	      InventoryLayout.findFreeCell(isz43, grid(4, 3), grid(4, 3, 1,0)));
+
+	// 4: a masked cell is skipped, not treated as scan-terminating
+	check("4 findFreeCell, masked (0,0) and occupied (1,0)", new Coord(2, 0),
+	      InventoryLayout.findFreeCell(isz43, grid(4, 3, 0,0), grid(4, 3, 1,0)));
+
+	// 5: genuinely full
+	check("5 findFreeCell, 2x2 full", null,
+	      InventoryLayout.findFreeCell(isz22, grid(2, 2), grid(2, 2, 0,0, 1,0, 0,1, 1,1)));
+    }
+
     public static void main(String[] args) {
 	findFitTests();
 	copyGridTests();
+	findFreeCellTests();
 	System.out.println();
 	System.out.println(failures == 0
 			   ? (total + " of " + total + " passed")

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -131,6 +131,12 @@ public class InventoryLayoutTest {
 	check("14a markOccupied marks the in-bounds cell", Boolean.TRUE, g14[3][2]);
 	check("14b markOccupied leaves the neighbour alone", Boolean.FALSE, g14[2][2]);
 
+	// 14c: a negative anchor clips on the low edge - without the >= 0 half of
+	// the guard this throws, and cases 14a/14b/15/16 would not notice
+	boolean[][] g14c = grid(4, 3);
+	InventoryLayout.markOccupied(g14c, isz43, new Coord(-1, -1), new Coord(2, 2), true);
+	check("14c markOccupied clips a negative anchor", Boolean.TRUE, g14c[0][0]);
+
 	// 15: clearing is symmetric
 	boolean[][] g15 = grid(4, 3, 1,1, 2,1);
 	InventoryLayout.markOccupied(g15, isz43, new Coord(1, 1), new Coord(2, 1), false);

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -122,10 +122,32 @@ public class InventoryLayoutTest {
 						      0,2, 1,2, 2,2)));
     }
 
+    private static void markOccupiedTests() {
+	Coord isz43 = new Coord(4, 3);
+
+	// 14: a 2x2 item anchored at (3,2) runs off both edges - must not throw
+	boolean[][] g14 = grid(4, 3);
+	InventoryLayout.markOccupied(g14, isz43, new Coord(3, 2), new Coord(2, 2), true);
+	check("14a markOccupied marks the in-bounds cell", Boolean.TRUE, g14[3][2]);
+	check("14b markOccupied leaves the neighbour alone", Boolean.FALSE, g14[2][2]);
+
+	// 15: clearing is symmetric
+	boolean[][] g15 = grid(4, 3, 1,1, 2,1);
+	InventoryLayout.markOccupied(g15, isz43, new Coord(1, 1), new Coord(2, 1), false);
+	check("15a markOccupied clears (1,1)", Boolean.FALSE, g15[1][1]);
+	check("15b markOccupied clears (2,1)", Boolean.FALSE, g15[2][1]);
+
+	// 16: a zero-sized item marks nothing (sprites smaller than sqsz)
+	boolean[][] g16 = grid(4, 3);
+	InventoryLayout.markOccupied(g16, isz43, new Coord(0, 0), new Coord(0, 1), true);
+	check("16 markOccupied with a zero slot marks nothing", Boolean.FALSE, g16[0][0]);
+    }
+
     public static void main(String[] args) {
 	findFreeCellTests();
 	findFitTests();
 	copyGridTests();
+	markOccupiedTests();
 	System.out.println();
 	System.out.println(failures == 0
 			   ? (total + " of " + total + " passed")

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -18,7 +18,7 @@ public class InventoryLayoutTest {
 	boolean ok = (expected == null) ? (actual == null) : expected.equals(actual);
 	if (!ok) failures++;
 	System.out.printf("%-52s %s%n", name,
-			  ok ? "PASS" : "FAIL (esperado " + expected + ", veio " + actual + ")");
+			  ok ? "PASS" : "FAIL (expected " + expected + ", got " + actual + ")");
     }
 
     /** Builds a w*h grid with the given (x,y) pairs set to true. */
@@ -36,58 +36,66 @@ public class InventoryLayoutTest {
 	// 6: horizontal fills across the row
 	boolean[][] g6 = grid(4, 3);
 	Coord a6 = InventoryLayout.findFit(g6, isz43, one, false);
-	check("6a findFit horizontal, primeiro 1x1", new Coord(0, 0), a6);
+	check("6a findFit horizontal, first 1x1", new Coord(0, 0), a6);
 	InventoryLayout.markGrid(g6, a6, one, true);
-	check("6b findFit horizontal, segundo 1x1", new Coord(1, 0),
+	check("6b findFit horizontal, second 1x1", new Coord(1, 0),
 	      InventoryLayout.findFit(g6, isz43, one, false));
 
 	// 7: vertical fills down the column
 	boolean[][] g7 = grid(4, 3);
 	Coord a7 = InventoryLayout.findFit(g7, isz43, one, true);
-	check("7a findFit vertical, primeiro 1x1", new Coord(0, 0), a7);
+	check("7a findFit vertical, first 1x1", new Coord(0, 0), a7);
 	InventoryLayout.markGrid(g7, a7, one, true);
-	check("7b findFit vertical, segundo 1x1", new Coord(0, 1),
+	check("7b findFit vertical, second 1x1", new Coord(0, 1),
 	      InventoryLayout.findFit(g7, isz43, one, true));
 
 	// 8: a 1x2 in a 3-row grid leaves one dead row in its column
 	Coord tall = new Coord(1, 2);
 	boolean[][] g8 = grid(4, 3);
 	Coord a8 = InventoryLayout.findFit(g8, isz43, tall, true);
-	check("8a findFit vertical, primeiro 1x2", new Coord(0, 0), a8);
+	check("8a findFit vertical, first 1x2", new Coord(0, 0), a8);
 	InventoryLayout.markGrid(g8, a8, tall, true);
-	check("8b findFit vertical, segundo 1x2", new Coord(1, 0),
+	check("8b findFit vertical, second 1x2", new Coord(1, 0),
 	      InventoryLayout.findFit(g8, isz43, tall, true));
 
 	// 9/10: the accepted fragmentation difference between the two modes
 	Coord isz24 = new Coord(2, 4);
 	Coord wide = new Coord(2, 1);
-	boolean[][] g9 = grid(2, 4, 0,0, 0,1, 0,2, 0,3, 1,0);   // cinco 1x1 por coluna
-	check("9  findFit vertical, 2x1 nao cabe", null,
+	boolean[][] g9 = grid(2, 4, 0,0, 0,1, 0,2, 0,3, 1,0);   // five 1x1 packed by column
+	check("9  findFit vertical, 2x1 does not fit", null,
 	      InventoryLayout.findFit(g9, isz24, wide, true));
-	boolean[][] g10 = grid(2, 4, 0,0, 1,0, 0,1, 1,1, 0,2);  // cinco 1x1 por linha
-	check("10 findFit horizontal, 2x1 cabe", new Coord(0, 3),
+	boolean[][] g10 = grid(2, 4, 0,0, 1,0, 0,1, 1,1, 0,2);  // five 1x1 packed by row
+	check("10 findFit horizontal, 2x1 fits", new Coord(0, 3),
 	      InventoryLayout.findFit(g10, isz24, wide, false));
 
 	// 11: blocked cells are never returned, in either mode
 	boolean[][] g11 = grid(4, 3, 0,0, 0,1, 0,2);
-	check("11a findFit horizontal respeita bloqueio", new Coord(1, 0),
+	check("11a findFit horizontal respects blocked cells", new Coord(1, 0),
 	      InventoryLayout.findFit(g11, isz43, one, false));
-	check("11b findFit vertical respeita bloqueio", new Coord(1, 0),
+	check("11b findFit vertical respects blocked cells", new Coord(1, 0),
 	      InventoryLayout.findFit(g11, isz43, one, true));
 
 	// 12: item bigger than the grid - negative bounds, must not throw
-	check("12a findFit horizontal, item maior que a grade", null,
+	check("12a findFit horizontal, item larger than grid", null,
 	      InventoryLayout.findFit(grid(2, 2), new Coord(2, 2), new Coord(3, 3), false));
-	check("12b findFit vertical, item maior que a grade", null,
+	check("12b findFit vertical, item larger than grid", null,
 	      InventoryLayout.findFit(grid(2, 2), new Coord(2, 2), new Coord(3, 3), true));
+    }
+
+    private static void copyGridTests() {
+	boolean[][] src = grid(4, 3, 1, 1);
+	boolean[][] copy = InventoryLayout.copyGrid(src, new Coord(4, 3));
+	copy[0][0] = true;
+	check("13 copyGrid does not alias the source", Boolean.FALSE, src[0][0]);
     }
 
     public static void main(String[] args) {
 	findFitTests();
+	copyGridTests();
 	System.out.println();
 	System.out.println(failures == 0
-			   ? (total + " de " + total + " passaram")
-			   : (failures + " de " + total + " falharam"));
+			   ? (total + " of " + total + " passed")
+			   : (failures + " of " + total + " failed"));
 	System.exit(failures == 0 ? 0 : 1);
     }
 }

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -1,0 +1,93 @@
+package haven.automated;
+
+import haven.Coord;
+
+/**
+ * Self-checking tests for InventoryLayout. No JUnit: lib/ has no test jar
+ * and build.xml has no test target.
+ *
+ * Run: javac -d build/classes -cp build/classes src/haven/automated/InventoryLayout*.java
+ *      java -cp build/classes haven.automated.InventoryLayoutTest
+ */
+public class InventoryLayoutTest {
+    private static int total = 0;
+    private static int failures = 0;
+
+    private static void check(String name, Object expected, Object actual) {
+	total++;
+	boolean ok = (expected == null) ? (actual == null) : expected.equals(actual);
+	if (!ok) failures++;
+	System.out.printf("%-52s %s%n", name,
+			  ok ? "PASS" : "FAIL (esperado " + expected + ", veio " + actual + ")");
+    }
+
+    /** Builds a w*h grid with the given (x,y) pairs set to true. */
+    private static boolean[][] grid(int w, int h, int... cells) {
+	boolean[][] g = new boolean[w][h];
+	for (int i = 0; i < cells.length; i += 2)
+	    g[cells[i]][cells[i + 1]] = true;
+	return g;
+    }
+
+    private static void findFitTests() {
+	Coord isz43 = new Coord(4, 3);
+	Coord one = new Coord(1, 1);
+
+	// 6: horizontal fills across the row
+	boolean[][] g6 = grid(4, 3);
+	Coord a6 = InventoryLayout.findFit(g6, isz43, one, false);
+	check("6a findFit horizontal, primeiro 1x1", new Coord(0, 0), a6);
+	InventoryLayout.markGrid(g6, a6, one, true);
+	check("6b findFit horizontal, segundo 1x1", new Coord(1, 0),
+	      InventoryLayout.findFit(g6, isz43, one, false));
+
+	// 7: vertical fills down the column
+	boolean[][] g7 = grid(4, 3);
+	Coord a7 = InventoryLayout.findFit(g7, isz43, one, true);
+	check("7a findFit vertical, primeiro 1x1", new Coord(0, 0), a7);
+	InventoryLayout.markGrid(g7, a7, one, true);
+	check("7b findFit vertical, segundo 1x1", new Coord(0, 1),
+	      InventoryLayout.findFit(g7, isz43, one, true));
+
+	// 8: a 1x2 in a 3-row grid leaves one dead row in its column
+	Coord tall = new Coord(1, 2);
+	boolean[][] g8 = grid(4, 3);
+	Coord a8 = InventoryLayout.findFit(g8, isz43, tall, true);
+	check("8a findFit vertical, primeiro 1x2", new Coord(0, 0), a8);
+	InventoryLayout.markGrid(g8, a8, tall, true);
+	check("8b findFit vertical, segundo 1x2", new Coord(1, 0),
+	      InventoryLayout.findFit(g8, isz43, tall, true));
+
+	// 9/10: the accepted fragmentation difference between the two modes
+	Coord isz24 = new Coord(2, 4);
+	Coord wide = new Coord(2, 1);
+	boolean[][] g9 = grid(2, 4, 0,0, 0,1, 0,2, 0,3, 1,0);   // cinco 1x1 por coluna
+	check("9  findFit vertical, 2x1 nao cabe", null,
+	      InventoryLayout.findFit(g9, isz24, wide, true));
+	boolean[][] g10 = grid(2, 4, 0,0, 1,0, 0,1, 1,1, 0,2);  // cinco 1x1 por linha
+	check("10 findFit horizontal, 2x1 cabe", new Coord(0, 3),
+	      InventoryLayout.findFit(g10, isz24, wide, false));
+
+	// 11: blocked cells are never returned, in either mode
+	boolean[][] g11 = grid(4, 3, 0,0, 0,1, 0,2);
+	check("11a findFit horizontal respeita bloqueio", new Coord(1, 0),
+	      InventoryLayout.findFit(g11, isz43, one, false));
+	check("11b findFit vertical respeita bloqueio", new Coord(1, 0),
+	      InventoryLayout.findFit(g11, isz43, one, true));
+
+	// 12: item bigger than the grid - negative bounds, must not throw
+	check("12a findFit horizontal, item maior que a grade", null,
+	      InventoryLayout.findFit(grid(2, 2), new Coord(2, 2), new Coord(3, 3), false));
+	check("12b findFit vertical, item maior que a grade", null,
+	      InventoryLayout.findFit(grid(2, 2), new Coord(2, 2), new Coord(3, 3), true));
+    }
+
+    public static void main(String[] args) {
+	findFitTests();
+	System.out.println();
+	System.out.println(failures == 0
+			   ? (total + " de " + total + " passaram")
+			   : (failures + " de " + total + " falharam"));
+	System.exit(failures == 0 ? 0 : 1);
+    }
+}

--- a/src/haven/automated/InventoryLayoutTest.java
+++ b/src/haven/automated/InventoryLayoutTest.java
@@ -232,6 +232,20 @@ public class InventoryLayoutTest {
 	      t23[1]);
 	check("23c assignTargets, two 1x2 and eight 1x1 all fit a 4x3", Boolean.TRUE,
 	      allPlaced(t23));
+
+	// 24: um item fixado de fora fica onde está, e nada é mandado por cima
+	// dele. É o gancho que o planejador de movimentos usa quando descobre
+	// que um item até cabe no alvo, mas não há como levá-lo até lá.
+	Coord[] sl24 = coords(cat(rep(1, 2, 1), rep(10, 1, 1)));
+	Coord[] cur24 = coords(2,2,                                  // o 2x1 ocupa (2,2)-(3,2)
+			       0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 3,1, 0,2, 1,2);
+	boolean[] pin24 = new boolean[sl24.length];
+	pin24[0] = true;
+	Coord[] t24 = InventoryLayout.assignTargets(grid(4, 3), isz43, sl24, cur24, false, pin24);
+	check("24a assignTargets keeps a caller-pinned item put", null, t24[0]);
+	check("24b assignTargets places everything else around it", 10, placed(t24));
+	check("24c assignTargets, no target lands on the caller-pinned item", Boolean.TRUE,
+	      noOverlap(t24, cur24, sl24, isz43));
     }
 
     private static void copyGridTests() {

--- a/src/haven/automated/InventoryMoves.java
+++ b/src/haven/automated/InventoryMoves.java
@@ -1,0 +1,122 @@
+package haven.automated;
+
+import haven.Coord;
+
+import java.util.*;
+
+/**
+ * Turns "where every item should end up" into "which messages to send".
+ *
+ * Widget messages are reliable and ordered (Connection.java:340,795 on the way
+ * out, 494-505 on the way in), so the server applies take/drop in the order
+ * they were sent. The client therefore never has to wait for a reply - it has
+ * to send a sequence the server will accept. That is what this class produces:
+ * every move is checked against a model of the server's own rules before it is
+ * emitted, so a refusal is impossible rather than merely unlikely.
+ *
+ * Depends on nothing but haven.Coord, like InventoryLayout, so it stays
+ * testable without a resource server.
+ */
+class InventoryMoves {
+    static final int TAKE = 0, DROP = 1;
+
+    /** One message. TAKE carries an item index, DROP a cell. */
+    static class Op {
+	final int kind;
+	final int item;
+	final Coord cell;
+
+	private Op(int kind, int item, Coord cell) {
+	    this.kind = kind;
+	    this.item = item;
+	    this.cell = cell;
+	}
+
+	static Op take(int item) { return new Op(TAKE, item, null); }
+	static Op drop(Coord cell) { return new Op(DROP, -1, cell); }
+
+	public String toString() {
+	    return (kind == TAKE) ? ("take " + item) : ("drop " + cell);
+	}
+    }
+
+    /**
+     * The server's view of one inventory, as far as take and drop are
+     * concerned. pos[i] == null means item i is on the cursor.
+     */
+    static class Sim {
+	final Coord isz;
+	final boolean[][] mask;
+	final Coord[] slots;
+	final Coord[] pos;
+	int hand = -1;
+
+	Sim(Coord isz, boolean[][] mask, Coord[] slots, Coord[] current) {
+	    this.isz = isz;
+	    this.mask = mask;
+	    this.slots = slots;
+	    this.pos = Arrays.copyOf(current, current.length);
+	}
+
+	static boolean one(Coord s) { return s.x == 1 && s.y == 1; }
+
+	/** Index of the item covering a cell, or -1. */
+	int at(int x, int y) {
+	    for (int i = 0; i < pos.length; i++) {
+		if (pos[i] == null) continue;
+		if (x >= pos[i].x && x < pos[i].x + slots[i].x
+		    && y >= pos[i].y && y < pos[i].y + slots[i].y)
+		    return i;
+	    }
+	    return -1;
+	}
+
+	/** Distinct items under a rect, or null if it leaves the grid or hits the mask. */
+	private Set<Integer> under(Coord p, Coord sz) {
+	    if (p.x < 0 || p.y < 0 || p.x + sz.x > isz.x || p.y + sz.y > isz.y)
+		return null;
+	    Set<Integer> out = new LinkedHashSet<>();
+	    for (int x = p.x; x < p.x + sz.x; x++)
+		for (int y = p.y; y < p.y + sz.y; y++) {
+		    if (mask[x][y]) return null;
+		    int o = at(x, y);
+		    if (o >= 0) out.add(o);
+		}
+	    return out;
+	}
+
+	boolean take(int item) {
+	    if (hand >= 0 || pos[item] == null) return false;
+	    hand = item;
+	    pos[item] = null;
+	    return true;
+	}
+
+	/**
+	 * Drops what is held. An empty rect always accepts. A rect covering
+	 * exactly one item swaps, but only between two 1x1 items - the case the
+	 * sorter's chain has always relied on and which demonstrably works.
+	 * Anything involving a multi-tile item is refused: whether the server
+	 * swaps in that direction has never been exercised, and guessing wrong
+	 * is what leaves a large item stuck on the cursor.
+	 */
+	boolean drop(Coord to) {
+	    if (hand < 0) return false;
+	    Set<Integer> u = under(to, slots[hand]);
+	    if (u == null) return false;
+	    if (u.isEmpty()) {
+		pos[hand] = to;
+		hand = -1;
+		return true;
+	    }
+	    if (u.size() != 1) return false;
+	    int other = u.iterator().next();
+	    if (!one(slots[hand]) || !one(slots[other])) return false;
+	    int held = hand;
+	    pos[other] = null;
+	    pos[held] = to;
+	    hand = other;
+	    return true;
+	}
+    }
+}

--- a/src/haven/automated/InventoryMoves.java
+++ b/src/haven/automated/InventoryMoves.java
@@ -201,11 +201,25 @@ class InventoryMoves {
      * an item moved to its own target is never in the way again, whereas the
      * old code shoved items into whatever cell was free - including cells
      * inside the very rect it was trying to clear.
+     *
+     * A chain is tried on a scratch copy of the simulator before it is
+     * committed. Any drop along the chain can be refused - not because the
+     * chain's starting item is unmovable, but because something further down
+     * is blocked, often a multi-tile item that simply has not had its own
+     * turn yet. Blaming that on the swap victim (returning its index as
+     * stuck, as an earlier version of this method did) pins the wrong item
+     * and gives up on a chain that would have worked once the real blocker
+     * moved. So a chain that cannot close is deferred instead - left alone
+     * for a later iteration of this same pass, once something else has moved
+     * and the board looks different. Deferrals are cleared on every commit,
+     * since a commit is the only event that can make a previously-blocked
+     * chain viable.
      */
     private static int sequence(boolean[][] mask, Coord isz, Coord[] slots,
 				Coord[] current, Coord[] targets, List<Op> ops) {
 	Sim sim = new Sim(isz, mask, slots, current);
 	boolean[] done = new boolean[slots.length];
+	boolean[] deferred = new boolean[slots.length];
 	for (int i = 0; i < slots.length; i++)
 	    done[i] = (targets[i] == null) || targets[i].equals(current[i]);
 
@@ -213,28 +227,60 @@ class InventoryMoves {
 	    int direct = -1, chain = -1;
 	    for (int i = 0; i < slots.length; i++) {
 		if (done[i]) continue;
-		int u = single(sim, targets[i], slots[i]);
+		int u = single(sim, targets[i], slots[i], i);
 		if (u == EMPTY) {
 		    // a multi-tile item only ever gets this shape, so give it
 		    // the free rect before a 1x1 can settle into it
 		    if (!Sim.one(slots[i])) { direct = i; break; }
 		    if (direct < 0) direct = i;
-		} else if (u >= 0 && Sim.one(slots[i]) && Sim.one(slots[u]) && chain < 0) {
+		} else if (!deferred[i] && u >= 0
+			  && Sim.one(slots[i]) && Sim.one(slots[u]) && chain < 0) {
 		    chain = i;
 		}
 	    }
 
-	    int start = (direct >= 0) ? direct : chain;
-	    if (start < 0) break;
-
-	    if (!sim.take(start)) return start;
-	    ops.add(Op.take(start));
-	    while (sim.hand >= 0) {
-		int held = sim.hand;
-		if (targets[held] == null || !sim.drop(targets[held])) return held;
-		ops.add(Op.drop(targets[held]));
-		done[held] = true;
+	    if (direct >= 0) {
+		// the target rect was just confirmed empty (self ignored), so
+		// this take/drop pair cannot fail - no trial needed
+		if (!sim.take(direct)) return direct;
+		ops.add(Op.take(direct));
+		if (!sim.drop(targets[direct])) return direct;
+		ops.add(Op.drop(targets[direct]));
+		done[direct] = true;
+		Arrays.fill(deferred, false);
+		continue;
 	    }
+
+	    if (chain >= 0) {
+		Sim trial = new Sim(isz, mask, slots, sim.pos);
+		if (!trial.take(chain)) return chain;
+		List<Op> trialOps = new ArrayList<>();
+		trialOps.add(Op.take(chain));
+		List<Integer> touched = new ArrayList<>();
+		boolean closed = true;
+		while (trial.hand >= 0) {
+		    int held = trial.hand;
+		    if (targets[held] == null || !trial.drop(targets[held])) {
+			closed = false;
+			break;
+		    }
+		    trialOps.add(Op.drop(targets[held]));
+		    touched.add(held);
+		}
+		if (closed) {
+		    sim = trial;
+		    ops.addAll(trialOps);
+		    for (int t : touched) done[t] = true;
+		    Arrays.fill(deferred, false);
+		} else {
+		    // not blamed on the swap victim - left for a later
+		    // iteration, once the real blocker has had its turn
+		    deferred[chain] = true;
+		}
+		continue;
+	    }
+
+	    break;
 	}
 
 	for (int i = 0; i < slots.length; i++)
@@ -252,9 +298,16 @@ class InventoryMoves {
 
     /**
      * The single item under `at`, EMPTY if the rect is clear, or MANY if it is
-     * unusable - more than one item, off the grid, or masked.
+     * unusable - more than one item, off the grid, or masked. `ignore` is
+     * treated as absent even though it is still sitting in the simulator: this
+     * is called before the take that would actually remove it, to predict what
+     * a subsequent drop will see. Without that, an item whose target rect
+     * overlaps its own current rect would report itself as the occupant and
+     * could never move - for a 1x1 this never bites, since a target equal to
+     * its own current cell is already handled as "nothing to do", but a
+     * multi-tile item's target can genuinely overlap where it is now.
      */
-    private static int single(Sim sim, Coord at, Coord sz) {
+    private static int single(Sim sim, Coord at, Coord sz, int ignore) {
 	if (at == null) return MANY;
 	if (at.x < 0 || at.y < 0 || at.x + sz.x > sim.isz.x || at.y + sz.y > sim.isz.y)
 	    return MANY;
@@ -262,11 +315,22 @@ class InventoryMoves {
 	for (int x = at.x; x < at.x + sz.x; x++)
 	    for (int y = at.y; y < at.y + sz.y; y++) {
 		if (sim.mask[x][y]) return MANY;
-		int o = sim.at(x, y);
+		int o = occupant(sim, x, y, ignore);
 		if (o < 0) continue;
 		if (found != EMPTY && found != o) return MANY;
 		found = o;
 	    }
 	return found;
+    }
+
+    /** Like Sim.at, but treats `ignore` as though it were not on the board. */
+    private static int occupant(Sim sim, int x, int y, int ignore) {
+	for (int i = 0; i < sim.pos.length; i++) {
+	    if (i == ignore || sim.pos[i] == null) continue;
+	    if (x >= sim.pos[i].x && x < sim.pos[i].x + sim.slots[i].x
+		&& y >= sim.pos[i].y && y < sim.pos[i].y + sim.slots[i].y)
+		return i;
+	}
+	return -1;
     }
 }

--- a/src/haven/automated/InventoryMoves.java
+++ b/src/haven/automated/InventoryMoves.java
@@ -42,7 +42,11 @@ class InventoryMoves {
 
     /**
      * The server's view of one inventory, as far as take and drop are
-     * concerned. pos[i] == null means item i is on the cursor.
+     * concerned. The cursor starts empty; pos[i] == null thereafter arises
+     * only through take, so current must be fully populated - a Sim built
+     * from a state where an item is already mid-drag would think the cursor
+     * is empty and allow a second take, reaching a state a single int hand
+     * cannot represent.
      */
     static class Sim {
 	final Coord isz;
@@ -51,6 +55,17 @@ class InventoryMoves {
 	final Coord[] pos;
 	int hand = -1;
 
+	/**
+	 * isz, mask, slots and the Coord objects inside them (including
+	 * current) are held, not copied - only the pos array itself is a
+	 * fresh copy. That is safe because nothing in this class ever writes
+	 * a Coord's x or y field; every move here is reference reassignment
+	 * (pos[i] = ...), never mutation. Callers must not mutate a Coord (or
+	 * mask, or slots) they have handed to a live Sim: haven.Coord is
+	 * mutable and in-place mutation is an idiom elsewhere in this
+	 * codebase, but InventorySorter's coords come from sub/div, which
+	 * always return fresh objects, so nothing here actually does that.
+	 */
 	Sim(Coord isz, boolean[][] mask, Coord[] slots, Coord[] current) {
 	    this.isz = isz;
 	    this.mask = mask;
@@ -85,6 +100,11 @@ class InventoryMoves {
 	    return out;
 	}
 
+	// An out-of-range item is a caller bug, not a refused move, so this
+	// throws rather than returning false like drop does - collapsing the
+	// two would let a planner indexing error masquerade as "that move
+	// wasn't possible" and quietly yield a worse plan instead of failing
+	// loudly in the tests.
 	boolean take(int item) {
 	    if (hand >= 0 || pos[item] == null) return false;
 	    hand = item;

--- a/src/haven/automated/InventoryMoves.java
+++ b/src/haven/automated/InventoryMoves.java
@@ -76,9 +76,12 @@ class InventoryMoves {
 	static boolean one(Coord s) { return s.x == 1 && s.y == 1; }
 
 	/** Index of the item covering a cell, or -1. */
-	int at(int x, int y) {
+	int at(int x, int y) { return at(x, y, -1); }
+
+	/** As above, but `ignore` is treated as though it were not on the board. */
+	int at(int x, int y, int ignore) {
 	    for (int i = 0; i < pos.length; i++) {
-		if (pos[i] == null) continue;
+		if (i == ignore || pos[i] == null) continue;
 		if (x >= pos[i].x && x < pos[i].x + slots[i].x
 		    && y >= pos[i].y && y < pos[i].y + slots[i].y)
 		    return i;
@@ -203,17 +206,29 @@ class InventoryMoves {
      * inside the very rect it was trying to clear.
      *
      * A chain is tried on a scratch copy of the simulator before it is
-     * committed. Any drop along the chain can be refused - not because the
-     * chain's starting item is unmovable, but because something further down
-     * is blocked, often a multi-tile item that simply has not had its own
-     * turn yet. Blaming that on the swap victim (returning its index as
-     * stuck, as an earlier version of this method did) pins the wrong item
-     * and gives up on a chain that would have worked once the real blocker
-     * moved. So a chain that cannot close is deferred instead - left alone
-     * for a later iteration of this same pass, once something else has moved
-     * and the board looks different. Deferrals are cleared on every commit,
-     * since a commit is the only event that can make a previously-blocked
-     * chain viable.
+     * committed. A drop along the chain is only ever refused because its
+     * target holds a multi-tile item - a 1x1 target either continues the
+     * swap or closes the chain. Blaming that on the swap victim (returning
+     * its index as stuck, as an earlier version of this method did) pins the
+     * wrong item: a swap only ever exchanges 1x1s among themselves, so it can
+     * never free the multi-tile item's cells, and pinning the victim does
+     * nothing to unblock the chain either - the multi-tile item is the actual
+     * obstruction. So a chain that cannot close is deferred instead, which
+     * does two things: it stops this same doomed candidate being re-picked
+     * forever, and it lets the other chain candidates in this pass - who may
+     * be blocked by the same item, or not blocked at all - still be tried. A
+     * deferred chain does not become viable later in this same pass: closing
+     * it requires the blocking multi-tile item to move, that item can only
+     * move via a direct rect that this pass has already established does not
+     * exist for it, and no chain commit can create one, since a chain only
+     * ever rearranges cells among the 1x1s already in it. Deferrals are
+     * cleared on every commit purely because the candidate set has changed
+     * and is worth rescanning, not because a previously-blocked chain could
+     * now succeed. What actually resolves the block is the tail below
+     * choosing to pin a multi-tile item over a 1x1: once that item is pinned,
+     * plan()'s outer loop reruns this method from scratch, with fresh
+     * deferred state, against a layout that no longer routes anything
+     * through the pinned item's cells.
      */
     private static int sequence(boolean[][] mask, Coord isz, Coord[] slots,
 				Coord[] current, Coord[] targets, List<Op> ops) {
@@ -273,8 +288,8 @@ class InventoryMoves {
 		    for (int t : touched) done[t] = true;
 		    Arrays.fill(deferred, false);
 		} else {
-		    // not blamed on the swap victim - left for a later
-		    // iteration, once the real blocker has had its turn
+		    // not blamed on the swap victim - just skipped, so the
+		    // rest of this pass can still try other candidates
 		    deferred[chain] = true;
 		}
 		continue;
@@ -315,22 +330,11 @@ class InventoryMoves {
 	for (int x = at.x; x < at.x + sz.x; x++)
 	    for (int y = at.y; y < at.y + sz.y; y++) {
 		if (sim.mask[x][y]) return MANY;
-		int o = occupant(sim, x, y, ignore);
+		int o = sim.at(x, y, ignore);
 		if (o < 0) continue;
 		if (found != EMPTY && found != o) return MANY;
 		found = o;
 	    }
 	return found;
-    }
-
-    /** Like Sim.at, but treats `ignore` as though it were not on the board. */
-    private static int occupant(Sim sim, int x, int y, int ignore) {
-	for (int i = 0; i < sim.pos.length; i++) {
-	    if (i == ignore || sim.pos[i] == null) continue;
-	    if (x >= sim.pos[i].x && x < sim.pos[i].x + sim.slots[i].x
-		&& y >= sim.pos[i].y && y < sim.pos[i].y + sim.slots[i].y)
-		return i;
-	}
-	return -1;
     }
 }

--- a/src/haven/automated/InventoryMoves.java
+++ b/src/haven/automated/InventoryMoves.java
@@ -139,4 +139,134 @@ class InventoryMoves {
 	    return true;
 	}
     }
+
+    /** A move list, the layout it realises, and whether anything had to stay put. */
+    static class Plan {
+	final List<Op> ops;
+	final Coord[] targets;      // null at i: item i is pinned where it is
+	final boolean pinnedMulti;  // a multi-tile item had to stay put
+
+	Plan(List<Op> ops, Coord[] targets, boolean pinnedMulti) {
+	    this.ops = ops;
+	    this.targets = targets;
+	    this.pinnedMulti = pinnedMulti;
+	}
+    }
+
+    /**
+     * The move list that takes the inventory from `current` to the layout
+     * InventoryLayout picks, or as close to it as can actually be carried out.
+     *
+     * An item can fit its target and still be impossible to carry there - a
+     * large item whose destination is blocked by another large item, for
+     * instance. When that happens the item is pinned and the layout is
+     * recomputed around it, which is the same pin-and-restart loop
+     * assignTargets already runs for items that do not fit at all. Each restart
+     * pins one more item and the all-pinned state is the original layout, so
+     * this terminates in at most n passes.
+     */
+    static Plan plan(boolean[][] mask, Coord isz, Coord[] slots,
+		     Coord[] current, boolean vertical) {
+	boolean[] pinned = new boolean[slots.length];
+	for (int attempt = 0; attempt <= slots.length; attempt++) {
+	    Coord[] targets = InventoryLayout.assignTargets(mask, isz, slots, current,
+							    vertical, pinned);
+	    List<Op> ops = new ArrayList<>();
+	    int stuck = sequence(mask, isz, slots, current, targets, ops);
+	    if (stuck < 0) {
+		boolean multi = false;
+		for (int i = 0; i < slots.length; i++)
+		    if ((targets[i] == null) && !Sim.one(slots[i]))
+			multi = true;
+		return new Plan(ops, targets, multi);
+	    }
+	    pinned[stuck] = true;
+	}
+	throw new AssertionError("pin-and-restart did not converge");
+    }
+
+    /**
+     * Emits the moves realising `targets` into `ops`. Returns -1 on success, or
+     * the index of an item that cannot be carried to its target.
+     *
+     * Two move shapes, and no others:
+     *
+     *  - direct: the target rect is empty, so take and drop land cleanly. This
+     *    is the only shape a multi-tile item ever gets.
+     *  - chain: a 1x1 whose target holds exactly one other 1x1. Dropping swaps,
+     *    the displaced item comes up on the cursor, and it is dropped on its own
+     *    target in turn. The cycle closes on the hole the first take opened.
+     *
+     * Preferring direct moves is what removes the old eviction step entirely:
+     * an item moved to its own target is never in the way again, whereas the
+     * old code shoved items into whatever cell was free - including cells
+     * inside the very rect it was trying to clear.
+     */
+    private static int sequence(boolean[][] mask, Coord isz, Coord[] slots,
+				Coord[] current, Coord[] targets, List<Op> ops) {
+	Sim sim = new Sim(isz, mask, slots, current);
+	boolean[] done = new boolean[slots.length];
+	for (int i = 0; i < slots.length; i++)
+	    done[i] = (targets[i] == null) || targets[i].equals(current[i]);
+
+	for (;;) {
+	    int direct = -1, chain = -1;
+	    for (int i = 0; i < slots.length; i++) {
+		if (done[i]) continue;
+		int u = single(sim, targets[i], slots[i]);
+		if (u == EMPTY) {
+		    // a multi-tile item only ever gets this shape, so give it
+		    // the free rect before a 1x1 can settle into it
+		    if (!Sim.one(slots[i])) { direct = i; break; }
+		    if (direct < 0) direct = i;
+		} else if (u >= 0 && Sim.one(slots[i]) && Sim.one(slots[u]) && chain < 0) {
+		    chain = i;
+		}
+	    }
+
+	    int start = (direct >= 0) ? direct : chain;
+	    if (start < 0) break;
+
+	    if (!sim.take(start)) return start;
+	    ops.add(Op.take(start));
+	    while (sim.hand >= 0) {
+		int held = sim.hand;
+		if (targets[held] == null || !sim.drop(targets[held])) return held;
+		ops.add(Op.drop(targets[held]));
+		done[held] = true;
+	    }
+	}
+
+	for (int i = 0; i < slots.length; i++)
+	    if (!done[i]) {
+		// prefer pinning a multi-tile item: it is the one whose rect
+		// blocks everything else, and pinning a 1x1 would not unstick it
+		if (!Sim.one(slots[i])) return i;
+	    }
+	for (int i = 0; i < slots.length; i++)
+	    if (!done[i]) return i;
+	return -1;
+    }
+
+    private static final int EMPTY = -1, MANY = -2;
+
+    /**
+     * The single item under `at`, EMPTY if the rect is clear, or MANY if it is
+     * unusable - more than one item, off the grid, or masked.
+     */
+    private static int single(Sim sim, Coord at, Coord sz) {
+	if (at == null) return MANY;
+	if (at.x < 0 || at.y < 0 || at.x + sz.x > sim.isz.x || at.y + sz.y > sim.isz.y)
+	    return MANY;
+	int found = EMPTY;
+	for (int x = at.x; x < at.x + sz.x; x++)
+	    for (int y = at.y; y < at.y + sz.y; y++) {
+		if (sim.mask[x][y]) return MANY;
+		int o = sim.at(x, y);
+		if (o < 0) continue;
+		if (found != EMPTY && found != o) return MANY;
+		found = o;
+	    }
+	return found;
+    }
 }

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -1,0 +1,119 @@
+package haven.automated;
+
+import haven.Coord;
+
+/**
+ * Self-checking tests for InventoryMoves. No JUnit: lib/ has no test jar and
+ * build.xml has no test target.
+ *
+ * Run: make check
+ */
+public class InventoryMovesTest {
+    private static int total = 0;
+    private static int failures = 0;
+
+    private static void check(String name, Object expected, Object actual) {
+	total++;
+	boolean ok = (expected == null) ? (actual == null) : expected.equals(actual);
+	if (!ok) failures++;
+	System.out.printf("%-58s %s%n", name,
+			  ok ? "PASS" : "FAIL (expected " + expected + ", got " + actual + ")");
+    }
+
+    private static boolean[][] grid(int w, int h, int... cells) {
+	boolean[][] g = new boolean[w][h];
+	for (int i = 0; i < cells.length; i += 2)
+	    g[cells[i]][cells[i + 1]] = true;
+	return g;
+    }
+
+    private static Coord[] coords(int... xy) {
+	Coord[] s = new Coord[xy.length / 2];
+	for (int i = 0; i < s.length; i++)
+	    s[i] = new Coord(xy[i * 2], xy[i * 2 + 1]);
+	return s;
+    }
+
+    private static int[] rep(int n, int w, int h) {
+	int[] out = new int[n * 2];
+	for (int i = 0; i < n; i++) { out[i * 2] = w; out[i * 2 + 1] = h; }
+	return out;
+    }
+
+    private static int[] cat(int[]... parts) {
+	int len = 0;
+	for (int[] p : parts) len += p.length;
+	int[] out = new int[len];
+	int o = 0;
+	for (int[] p : parts) { System.arraycopy(p, 0, out, o, p.length); o += p.length; }
+	return out;
+    }
+
+    private static void simTests() {
+	Coord isz43 = new Coord(4, 3);
+	// duas peças: um 2x1 em (0,0)-(1,0) e um 1x1 em (2,0)
+	Coord[] slots = coords(2,1, 1,1);
+	Coord[] cur = coords(0,0, 2,0);
+
+	// 1: take de mão vazia funciona, take com a mão ocupada não
+	InventoryMoves.Sim s1 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
+	check("1a take with an empty cursor", Boolean.TRUE, s1.take(0));
+	check("1b take with a full cursor is refused", Boolean.FALSE, s1.take(1));
+
+	// 2: drop em retângulo vazio funciona
+	InventoryMoves.Sim s2 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
+	s2.take(0);
+	check("2a drop into an empty rect", Boolean.TRUE, s2.drop(new Coord(0, 1)));
+	check("2b the cursor is empty afterwards", -1, s2.hand);
+	check("2c the item is where it was dropped", new Coord(0, 1), s2.pos[0]);
+
+	// 3: drop fora dos limites é recusado
+	InventoryMoves.Sim s3 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
+	s3.take(0);
+	check("3 drop past the right edge is refused", Boolean.FALSE, s3.drop(new Coord(3, 0)));
+
+	// 4: drop em célula mascarada é recusado
+	InventoryMoves.Sim s4 = new InventoryMoves.Sim(isz43, grid(4, 3, 0,2), slots, cur);
+	s4.take(0);
+	check("4 drop onto a masked cell is refused", Boolean.FALSE, s4.drop(new Coord(0, 2)));
+
+	// 5: 1x1 sobre 1x1 troca - o mecanismo da corrente, o único caso de
+	// troca que o planejador tem permissão de usar
+	Coord[] sl5 = coords(rep(2, 1, 1));
+	Coord[] cur5 = coords(0,0, 1,0);
+	InventoryMoves.Sim s5 = new InventoryMoves.Sim(isz43, grid(4, 3), sl5, cur5);
+	s5.take(0);
+	check("5a 1x1 dropped onto a 1x1 swaps", Boolean.TRUE, s5.drop(new Coord(1, 0)));
+	check("5b the swapped item is now on the cursor", 1, s5.hand);
+	check("5c the dropped item took its place", new Coord(1, 0), s5.pos[0]);
+
+	// 6: 1x1 sobre item grande NÃO troca. É a política conservadora: essa
+	// troca é justamente o acidente que hoje deixa o item grande na mão.
+	InventoryMoves.Sim s6 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
+	s6.take(1);
+	check("6 1x1 dropped onto a multi-tile item is refused", Boolean.FALSE,
+	      s6.drop(new Coord(0, 0)));
+
+	// 7: item grande sobre um único 1x1 também não troca
+	InventoryMoves.Sim s7 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
+	s7.take(0);
+	check("7 a multi-tile item dropped onto a 1x1 is refused", Boolean.FALSE,
+	      s7.drop(new Coord(2, 0)));
+
+	// 8: dois itens embaixo nunca aceita
+	Coord[] sl8 = coords(2,1, 1,1, 1,1);
+	Coord[] cur8 = coords(0,2, 0,0, 1,0);
+	InventoryMoves.Sim s8 = new InventoryMoves.Sim(isz43, grid(4, 3), sl8, cur8);
+	s8.take(0);
+	check("8 a drop covering two items is refused", Boolean.FALSE, s8.drop(new Coord(0, 0)));
+    }
+
+    public static void main(String[] args) {
+	simTests();
+	System.out.println();
+	System.out.println(failures == 0
+			   ? (total + " of " + total + " passed")
+			   : (failures + " of " + total + " failed"));
+	System.exit(failures == 0 ? 0 : 1);
+    }
+}

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -239,10 +239,116 @@ public class InventoryMovesTest {
 	      pinnedCount(p9.targets) <= 1);
     }
 
+    /**
+     * Builds a layout with `nmulti` multi-tile items and 1x1 filling the rest
+     * except `freeCells`. Returns {slots, current} or null if the multi-tile
+     * items would not fit - the caller just skips those draws.
+     */
+    private static Coord[][] randomLayout(Coord isz, int nmulti, int freeCells,
+					  java.util.Random rnd) {
+	Coord[] shapes = coords(2,1, 1,2, 2,2, 3,1);
+	java.util.List<Coord> sl = new java.util.ArrayList<>();
+	java.util.List<Coord> at = new java.util.ArrayList<>();
+	boolean[][] used = new boolean[isz.x][isz.y];
+	for (int i = 0; i < nmulti; i++) {
+	    Coord sz = shapes[rnd.nextInt(shapes.length)];
+	    boolean placed = false;
+	    for (int tries = 0; tries < 60 && !placed; tries++) {
+		int x = rnd.nextInt(Math.max(1, isz.x - sz.x + 1));
+		int y = rnd.nextInt(Math.max(1, isz.y - sz.y + 1));
+		if (x + sz.x > isz.x || y + sz.y > isz.y) continue;
+		boolean ok = true;
+		for (int dx = 0; dx < sz.x && ok; dx++)
+		    for (int dy = 0; dy < sz.y && ok; dy++)
+			if (used[x + dx][y + dy]) ok = false;
+		if (!ok) continue;
+		for (int dx = 0; dx < sz.x; dx++)
+		    for (int dy = 0; dy < sz.y; dy++)
+			used[x + dx][y + dy] = true;
+		sl.add(sz);
+		at.add(new Coord(x, y));
+		placed = true;
+	    }
+	    if (!placed) return null;
+	}
+	java.util.List<Coord> free = new java.util.ArrayList<>();
+	for (int y = 0; y < isz.y; y++)
+	    for (int x = 0; x < isz.x; x++)
+		if (!used[x][y]) free.add(new Coord(x, y));
+	if (free.size() < freeCells) return null;
+	java.util.Collections.shuffle(free, rnd);
+	for (int i = freeCells; i < free.size(); i++) {
+	    sl.add(new Coord(1, 1));
+	    at.add(free.get(i));
+	}
+	return new Coord[][] {sl.toArray(new Coord[0]), at.toArray(new Coord[0])};
+    }
+
+    /**
+     * Uma configuração de sweep; relata o primeiro layout que falhar, se
+     * algum falhar. "Falhar" cobre duas coisas, não só uma: uma recusa
+     * (replay != null) e um plano bom demais na forma, ruim demais no
+     * conteúdo - fixar mais itens do que existem itens grandes no layout.
+     * Essa segunda checagem é a razão de o sweep existir: o Task 3 já
+     * mandou um planejador que passava em replay() sempre, porque um plano
+     * que não move nada nunca é recusado, e mesmo assim fixava 21 de 22
+     * itens num armário cheio. Só contar itens fixados pegou aquilo; um
+     * sweep que só chamasse replay() teria deixado passar.
+     */
+    private static void sweep(String name, Coord isz, int nmulti, int freeCells,
+			      boolean vertical, long seed) {
+	java.util.Random rnd = new java.util.Random(seed);
+	int runs = 2000, drawn = 0;
+	String first = null;
+	for (int r = 0; r < runs && first == null; r++) {
+	    Coord[][] layout = randomLayout(isz, nmulti, freeCells, rnd);
+	    if (layout == null) continue;
+	    drawn++;
+	    Coord[] slots = layout[0], cur = layout[1];
+	    boolean[][] mask = grid(isz.x, isz.y);
+	    InventoryMoves.Plan p = InventoryMoves.plan(mask, isz, slots, cur, vertical);
+	    String bad = replay(mask, isz, slots, cur, p);
+	    if (bad == null) {
+		// invariante medida empiricamente sobre estas mesmas configurações
+		// (máximo observado nunca passou de nmulti, em 2000 layouts cada):
+		// só um item grande fica pra trás, nunca um 1x1. Para nmulti == 0
+		// isso vira "nada fica fixado", que é o caso puro-permutação.
+		int pinned = pinnedCount(p.targets);
+		if (pinned > nmulti)
+		    bad = "pinned " + pinned + " items, more than the " + nmulti
+			+ " multi-tile item(s) in the layout";
+	    }
+	    if (bad != null) first = "layout " + r + ": " + bad;
+	}
+	// só reporta "poucos layouts utilizáveis" se nada mais específico já
+	// falhou - um defeito real interrompe o laço logo nos primeiros
+	// sorteios, e essa contagem baixa não pode apagar o índice e a causa
+	// que já foram encontrados
+	if (first == null && drawn < runs / 2)
+	    first = "only " + drawn + " of " + runs + " layouts were usable";
+	check(name, null, first);
+    }
+
+    private static void sweepTests() {
+	Coord isz56 = new Coord(5, 6);
+	Coord isz43 = new Coord(4, 3);
+	for (int free : new int[] {0, 1, 3, 8}) {
+	    sweep("18." + free + "h sweep 5x6, 2 multi, " + free + " free, horizontal",
+		  isz56, 2, free, false, 42 + free);
+	    sweep("18." + free + "v sweep 5x6, 2 multi, " + free + " free, vertical",
+		  isz56, 2, free, true, 42 + free);
+	}
+	sweep("19a sweep 5x6, no multi, packed", isz56, 0, 0, false, 7);
+	sweep("19b sweep 4x3, 1 multi, packed", isz43, 1, 0, false, 9);
+	sweep("19c sweep 4x3, 1 multi, packed, vertical", isz43, 1, 0, true, 9);
+    }
+
     public static void main(String[] args) {
 	simTests();
 	System.out.println();
 	planTests();
+	System.out.println();
+	sweepTests();
 	System.out.println();
 	System.out.println(failures == 0
 			   ? (total + " of " + total + " passed")

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -241,15 +241,20 @@ public class InventoryMovesTest {
 
     /**
      * Builds a layout with `nmulti` multi-tile items and 1x1 filling the rest
-     * except `freeCells`. Returns {slots, current} or null if the multi-tile
-     * items would not fit - the caller just skips those draws.
+     * except `freeCells`. `mask` cells are treated as already occupied, so
+     * neither the multi-tile items nor the 1x1 filler ever land on one -
+     * exactly what a real container with permanently blocked squares
+     * (Inventory.sqmask) does. Returns {slots, current} or null if the
+     * multi-tile items would not fit - the caller just skips those draws.
      */
     private static Coord[][] randomLayout(Coord isz, int nmulti, int freeCells,
-					  java.util.Random rnd) {
+					  boolean[][] mask, java.util.Random rnd) {
 	Coord[] shapes = coords(2,1, 1,2, 2,2, 3,1);
 	java.util.List<Coord> sl = new java.util.ArrayList<>();
 	java.util.List<Coord> at = new java.util.ArrayList<>();
 	boolean[][] used = new boolean[isz.x][isz.y];
+	for (int x = 0; x < isz.x; x++)
+	    used[x] = java.util.Arrays.copyOf(mask[x], isz.y);
 	for (int i = 0; i < nmulti; i++) {
 	    Coord sz = shapes[rnd.nextInt(shapes.length)];
 	    boolean placed = false;
@@ -297,26 +302,38 @@ public class InventoryMovesTest {
      */
     private static void sweep(String name, Coord isz, int nmulti, int freeCells,
 			      boolean vertical, long seed) {
+	// invariante medida empiricamente sobre estas mesmas configurações
+	// (máximo observado nunca passou de nmulti, em 2000 layouts cada):
+	// só um item grande fica pra trás, nunca um 1x1. Para nmulti == 0
+	// isso vira "nada fica fixado", que é o caso puro-permutação.
+	sweep(name, isz, nmulti, freeCells, vertical, seed, grid(isz.x, isz.y), nmulti);
+    }
+
+    /**
+     * As above, but with a mask - the same grid is threaded through both
+     * plan() and replay(), which is the whole point: passing an unmasked grid
+     * to either one would make a masked case pass for free instead of
+     * actually exercising the mask. `pinnedBound` is a separate parameter
+     * rather than always `nmulti` because a masked bound has to be measured,
+     * not assumed - see sweepTests() for the measurements behind the calls
+     * below.
+     */
+    private static void sweep(String name, Coord isz, int nmulti, int freeCells,
+			      boolean vertical, long seed, boolean[][] mask, int pinnedBound) {
 	java.util.Random rnd = new java.util.Random(seed);
 	int runs = 2000, drawn = 0;
 	String first = null;
 	for (int r = 0; r < runs && first == null; r++) {
-	    Coord[][] layout = randomLayout(isz, nmulti, freeCells, rnd);
+	    Coord[][] layout = randomLayout(isz, nmulti, freeCells, mask, rnd);
 	    if (layout == null) continue;
 	    drawn++;
 	    Coord[] slots = layout[0], cur = layout[1];
-	    boolean[][] mask = grid(isz.x, isz.y);
 	    InventoryMoves.Plan p = InventoryMoves.plan(mask, isz, slots, cur, vertical);
 	    String bad = replay(mask, isz, slots, cur, p);
 	    if (bad == null) {
-		// invariante medida empiricamente sobre estas mesmas configurações
-		// (máximo observado nunca passou de nmulti, em 2000 layouts cada):
-		// só um item grande fica pra trás, nunca um 1x1. Para nmulti == 0
-		// isso vira "nada fica fixado", que é o caso puro-permutação.
 		int pinned = pinnedCount(p.targets);
-		if (pinned > nmulti)
-		    bad = "pinned " + pinned + " items, more than the " + nmulti
-			+ " multi-tile item(s) in the layout";
+		if (pinned > pinnedBound)
+		    bad = "pinned " + pinned + " items, more than the bound of " + pinnedBound;
 	    }
 	    if (bad != null) first = "layout " + r + ": " + bad;
 	}
@@ -341,6 +358,37 @@ public class InventoryMovesTest {
 	sweep("19a sweep 5x6, no multi, packed", isz56, 0, 0, false, 7);
 	sweep("19b sweep 4x3, 1 multi, packed", isz43, 1, 0, false, 9);
 	sweep("19c sweep 4x3, 1 multi, packed, vertical", isz43, 1, 0, true, 9);
+
+	// 20.x/21.x: as mesmas 2000 tiradas de antes, mas agora com células
+	// mascaradas - a única cobertura de máscara que passa por plan() em vez
+	// de cutucar Sim.drop() direto (ver simTests teste 4). A máscara é a
+	// mesma tanto em randomLayout (via used) quanto em plan/replay abaixo:
+	// nenhum dos dois vê uma grade mais livre do que a outra.
+	//
+	// O limite de itens fixados foi medido antes de virar asserção, do
+	// mesmo jeito que o limite sem máscara: instrumentando uma cópia
+	// descartável destas mesmas configurações por 2000 tiradas cada. Em
+	// todas elas o máximo observado foi exatamente nmulti (nunca mais),
+	// então o limite abaixo é o mesmo de sempre, só que agora verificado
+	// também com máscara em vez de só suposto.
+	boolean[][] mask56 = grid(5, 6, 2,2, 4,0, 0,5, 1,3, 3,1, 4,5);
+	sweep("20a masked sweep 5x6, 2 multi, 3 free, horizontal",
+	      isz56, 2, 3, false, 55, mask56, 2);
+	sweep("20b masked sweep 5x6, 2 multi, 3 free, vertical",
+	      isz56, 2, 3, true, 55, mask56, 2);
+	// pacote quase até a última célula livre - o caso que mais aperta a
+	// interação entre assignTargets (que decide alvos vendo a máscara) e
+	// Sim (que recusa jogadas vendo a mesma máscara)
+	sweep("20c masked sweep 5x6, 2 multi, 0 free, horizontal",
+	      isz56, 2, 0, false, 55, mask56, 2);
+	sweep("20d masked sweep 5x6, 2 multi, 0 free, vertical",
+	      isz56, 2, 0, true, 55, mask56, 2);
+
+	boolean[][] mask43 = grid(4, 3, 2,1, 0,2);
+	sweep("21a masked sweep 4x3, 1 multi, packed, horizontal",
+	      isz43, 1, 0, false, 77, mask43, 1);
+	sweep("21b masked sweep 4x3, 1 multi, packed, vertical",
+	      isz43, 1, 0, true, 77, mask43, 1);
     }
 
     public static void main(String[] args) {

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -51,34 +51,34 @@ public class InventoryMovesTest {
 
     private static void simTests() {
 	Coord isz43 = new Coord(4, 3);
-	// duas peças: um 2x1 em (0,0)-(1,0) e um 1x1 em (2,0)
+	// two pieces: a 2x1 at (0,0)-(1,0) and a 1x1 at (2,0)
 	Coord[] slots = coords(2,1, 1,1);
 	Coord[] cur = coords(0,0, 2,0);
 
-	// 1: take de mão vazia funciona, take com a mão ocupada não
+	// 1: a take off an empty cursor works, a take with a full one does not
 	InventoryMoves.Sim s1 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
 	check("1a take with an empty cursor", Boolean.TRUE, s1.take(0));
 	check("1b take with a full cursor is refused", Boolean.FALSE, s1.take(1));
 
-	// 2: drop em retângulo vazio funciona
+	// 2: a drop into an empty rect works
 	InventoryMoves.Sim s2 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
 	s2.take(0);
 	check("2a drop into an empty rect", Boolean.TRUE, s2.drop(new Coord(0, 1)));
 	check("2b the cursor is empty afterwards", -1, s2.hand);
 	check("2c the item is where it was dropped", new Coord(0, 1), s2.pos[0]);
 
-	// 3: drop fora dos limites é recusado
+	// 3: a drop out of bounds is refused
 	InventoryMoves.Sim s3 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
 	s3.take(0);
 	check("3 drop past the right edge is refused", Boolean.FALSE, s3.drop(new Coord(3, 0)));
 
-	// 4: drop em célula mascarada é recusado
+	// 4: a drop onto a masked cell is refused
 	InventoryMoves.Sim s4 = new InventoryMoves.Sim(isz43, grid(4, 3, 0,2), slots, cur);
 	s4.take(0);
 	check("4 drop onto a masked cell is refused", Boolean.FALSE, s4.drop(new Coord(0, 2)));
 
-	// 5: 1x1 sobre 1x1 troca - o mecanismo da corrente, o único caso de
-	// troca que o planejador tem permissão de usar
+	// 5: 1x1 onto 1x1 swaps - the mechanism the chain rides on, and the
+	// only swap the planner is allowed to use
 	Coord[] sl5 = coords(rep(2, 1, 1));
 	Coord[] cur5 = coords(0,0, 1,0);
 	InventoryMoves.Sim s5 = new InventoryMoves.Sim(isz43, grid(4, 3), sl5, cur5);
@@ -87,20 +87,21 @@ public class InventoryMovesTest {
 	check("5b the swapped item is now on the cursor", 1, s5.hand);
 	check("5c the dropped item took its place", new Coord(1, 0), s5.pos[0]);
 
-	// 6: 1x1 sobre item grande NÃO troca. É a política conservadora: essa
-	// troca é justamente o acidente que hoje deixa o item grande na mão.
+	// 6: 1x1 onto a multi-tile item does NOT swap. That is the conservative
+	// policy: this swap is exactly the accident that leaves the multi-tile
+	// item stuck on the cursor today.
 	InventoryMoves.Sim s6 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
 	s6.take(1);
 	check("6 1x1 dropped onto a multi-tile item is refused", Boolean.FALSE,
 	      s6.drop(new Coord(0, 0)));
 
-	// 7: item grande sobre um único 1x1 também não troca
+	// 7: a multi-tile item onto a single 1x1 does not swap either
 	InventoryMoves.Sim s7 = new InventoryMoves.Sim(isz43, grid(4, 3), slots, cur);
 	s7.take(0);
 	check("7 a multi-tile item dropped onto a 1x1 is refused", Boolean.FALSE,
 	      s7.drop(new Coord(2, 0)));
 
-	// 8: dois itens embaixo nunca aceita
+	// 8: two items underneath is never accepted
 	Coord[] sl8 = coords(2,1, 1,1, 1,1);
 	Coord[] cur8 = coords(0,2, 0,0, 1,0);
 	InventoryMoves.Sim s8 = new InventoryMoves.Sim(isz43, grid(4, 3), sl8, cur8);
@@ -153,10 +154,10 @@ public class InventoryMovesTest {
     private static void planTests() {
 	Coord isz43 = new Coord(4, 3);
 
-	// 9: um armário 4x3 cheio até a última célula, com um 2x1 que precisa
-	// sair de (2,2). É o relato do usuário: hoje a evicção não encontra
-	// célula livre, avisa "inventory too full" e a fase 2 deixa o item
-	// grande na mão. O plano tem de sair sem uma única recusa.
+	// 9: a 4x3 cupboard packed to the last cell, with a 2x1 that has to
+	// leave (2,2). This is the user's report: today eviction finds no free
+	// cell, warns "inventory too full", and phase 2 leaves the multi-tile
+	// item on the cursor. The plan has to come out without a single refusal.
 	Coord[] sl9 = coords(cat(rep(1, 2, 1), rep(10, 1, 1)));
 	Coord[] cur9 = coords(2,2,
 			      0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 3,1, 0,2, 1,2);
@@ -164,8 +165,8 @@ public class InventoryMovesTest {
 	check("9 full 4x3 with a 2x1 that has to move", null,
 	      replay(grid(4, 3), isz43, sl9, cur9, p9));
 
-	// 10: o mesmo armário com uma célula livre. Hoje esse caso falha em
-	// silêncio - nenhuma mensagem, e mesmo assim um item no cursor.
+	// 10: the same cupboard with one free cell. Today this case fails
+	// silently - no message, and an item left on the cursor anyway.
 	Coord[] sl10 = coords(cat(rep(1, 2, 1), rep(9, 1, 1)));
 	Coord[] cur10 = coords(2,2,
 			       0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 0,2, 1,2);
@@ -173,39 +174,40 @@ public class InventoryMovesTest {
 	check("10 same cupboard with one free cell", null,
 	      replay(grid(4, 3), isz43, sl10, cur10, p10));
 
-	// 11: doze 1x1 num 4x3 cheio, em ordem invertida. Puro ciclo: sem
-	// nenhuma célula livre, a única saída é a corrente de trocas.
+	// 11: twelve 1x1 in a full 4x3, in reverse order. A pure cycle: with no
+	// free cell at all, the swap chain is the only way out.
 	Coord[] sl11 = coords(rep(12, 1, 1));
 	Coord[] cur11 = coords(3,2, 2,2, 1,2, 0,2, 3,1, 2,1, 1,1, 0,1, 3,0, 2,0, 1,0, 0,0);
 	InventoryMoves.Plan p11 = InventoryMoves.plan(grid(4, 3), isz43, sl11, cur11, false);
 	check("11 a full grid of 1x1 in reverse order", null,
 	      replay(grid(4, 3), isz43, sl11, cur11, p11));
 
-	// 12: dois itens grandes disputando lugar. Fora de escopo resolver o
-	// movimento em cadeia deles - mas o plano continua obrigado a ser
-	// executável, fixando o que não dá para mover.
+	// 12: two multi-tile items contending for the same spot. Solving their
+	// chained movement is out of scope - but the plan is still required to
+	// be executable, pinning whatever cannot be moved.
 	Coord[] sl12 = coords(2,1, 2,1);
 	Coord[] cur12 = coords(2,0, 0,1);
 	InventoryMoves.Plan p12 = InventoryMoves.plan(grid(4, 3), isz43, sl12, cur12, false);
 	check("12 two multi-tile items contending for one spot", null,
 	      replay(grid(4, 3), isz43, sl12, cur12, p12));
 
-	// 13: nada a fazer produz plano vazio, não uma volta inútil
+	// 13: nothing to do produces an empty plan, not a pointless round trip
 	Coord[] sl13 = coords(rep(2, 1, 1));
 	Coord[] cur13 = coords(0,0, 1,0);
 	InventoryMoves.Plan p13 = InventoryMoves.plan(grid(4, 3), isz43, sl13, cur13, false);
 	check("13a an already sorted inventory plans no moves", 0, p13.ops.size());
 	check("13b and reports nothing pinned", Boolean.FALSE, p13.pinnedMulti);
 
-	// 14: modo vertical passa pelo mesmo contrato
+	// 14: vertical mode is held to the same contract
 	InventoryMoves.Plan p14 = InventoryMoves.plan(grid(4, 3), isz43, sl9, cur9, true);
 	check("14 full 4x3 with a 2x1, vertical fill", null,
 	      replay(grid(4, 3), isz43, sl9, cur9, p14));
 
-	// 15: um 2x1 cujo alvo cobre a própria célula atual - exatamente o caso
-	// em que single() via o próprio item como "ocupante" e nunca liberava a
-	// vaga. Ignorar quem está prestes a ser pego é o que permite o take;
-	// sem isso o item ficava fixado para sempre, mesmo sobrando espaço.
+	// 15: a 2x1 whose target covers its own current cell - exactly the case
+	// where single() saw the item itself as the "occupant" and never freed
+	// the spot. Ignoring the item that is about to be picked up is what
+	// makes the take possible; without that the item stayed pinned forever,
+	// even with room to spare.
 	Coord[] sl15 = coords(2,1);
 	Coord[] cur15 = coords(1,0);
 	InventoryMoves.Plan p15 = InventoryMoves.plan(grid(4, 3), isz43, sl15, cur15, false);
@@ -214,14 +216,14 @@ public class InventoryMovesTest {
 	check("15b and the item actually leaves where it started", Boolean.TRUE,
 	      p15.targets[0] != null && !p15.targets[0].equals(cur15[0]));
 
-	// 16: uma grade 3x2 cheia com um 2x1 e quatro 1x1. A corrente que troca
-	// os 1x1 entre si esbarra, no meio do caminho, num alvo que o 2x1 ainda
-	// ocupa - ele só sai de lá mais tarde, quando (nunca, nesta grade sem
-	// folga) sobrar espaço para ele. Commitando a corrente sem testar antes,
-	// o código antigo culpava a vítima da troca pelo bloqueio e fixava o
-	// item errado; a grade inteira saía quase toda fixada. Adiando a
-	// corrente em vez disso, só o 2x1 - que de fato não cabe em lugar
-	// nenhum numa grade cheia - fica pra trás.
+	// 16: a packed 3x2 grid with one 2x1 and four 1x1. The chain that swaps
+	// the 1x1 among themselves runs, halfway through, into a target the 2x1
+	// still occupies - and the 2x1 only leaves later, once (never, on a grid
+	// this tight) there is room for it. Committing the chain without trying
+	// it first, the old code blamed the swap victim for the block and pinned
+	// the wrong item; nearly the whole grid came out pinned. Deferring the
+	// chain instead, only the 2x1 - which genuinely fits nowhere on a full
+	// grid - is left behind.
 	Coord isz32 = new Coord(3, 2);
 	Coord[] sl16 = coords(2,1, 1,1, 1,1, 1,1, 1,1);
 	Coord[] cur16 = coords(1,0, 0,1, 1,1, 2,1, 0,0);
@@ -230,11 +232,11 @@ public class InventoryMovesTest {
 	      replay(grid(3, 2), isz32, sl16, cur16, p16));
 	check("16b and only the multi-tile item ends up pinned", 1, pinnedCount(p16.targets));
 
-	// 17: a mesma grade cheia do teste 9, mas agora checando se ela
-	// realmente ordena - não só se executa sem recusa. É a asserção que
-	// teria pegado o defeito inteiro: antes das correções, plan() passava
-	// no replay já que fixar um item nunca é uma recusa, mas saía da
-	// função com quase a grade inteira fixada em vez de ordenada.
+	// 17: the same packed grid as test 9, but now checking that it actually
+	// sorts - not merely that it runs without a refusal. This is the
+	// assertion that would have caught the whole defect: before the fixes,
+	// plan() passed replay() because pinning an item is never a refusal, and
+	// still returned with nearly the whole grid pinned instead of sorted.
 	check("17 a packed grid with one multi-tile item pins at most it", Boolean.TRUE,
 	      pinnedCount(p9.targets) <= 1);
     }
@@ -290,22 +292,22 @@ public class InventoryMovesTest {
     }
 
     /**
-     * Uma configuração de sweep; relata o primeiro layout que falhar, se
-     * algum falhar. "Falhar" cobre duas coisas, não só uma: uma recusa
-     * (replay != null) e um plano bom demais na forma, ruim demais no
-     * conteúdo - fixar mais itens do que existem itens grandes no layout.
-     * Essa segunda checagem é a razão de o sweep existir: o Task 3 já
-     * mandou um planejador que passava em replay() sempre, porque um plano
-     * que não move nada nunca é recusado, e mesmo assim fixava 21 de 22
-     * itens num armário cheio. Só contar itens fixados pegou aquilo; um
-     * sweep que só chamasse replay() teria deixado passar.
+     * One sweep configuration; reports the first layout that fails, if any
+     * does. "Fails" covers two things, not one: a refusal (replay != null),
+     * and a plan that is fine in shape but wrong in substance - pinning more
+     * items than there are multi-tile items in the layout. That second check
+     * is the reason the sweep exists: Task 3 already shipped a planner that
+     * passed replay() every time, because a plan that moves nothing is never
+     * refused, and still pinned 21 of 22 items in a packed cupboard. Only
+     * counting pinned items caught that; a sweep calling replay() alone would
+     * have let it through.
      */
     private static void sweep(String name, Coord isz, int nmulti, int freeCells,
 			      boolean vertical, long seed) {
-	// invariante medida empiricamente sobre estas mesmas configurações
-	// (máximo observado nunca passou de nmulti, em 2000 layouts cada):
-	// só um item grande fica pra trás, nunca um 1x1. Para nmulti == 0
-	// isso vira "nada fica fixado", que é o caso puro-permutação.
+	// an invariant measured empirically over these same configurations
+	// (the observed maximum never exceeded nmulti, over 2000 layouts each):
+	// only a multi-tile item is left behind, never a 1x1. For nmulti == 0
+	// this becomes "nothing is pinned", which is the pure-permutation case.
 	sweep(name, isz, nmulti, freeCells, vertical, seed, grid(isz.x, isz.y), nmulti);
     }
 
@@ -337,10 +339,10 @@ public class InventoryMovesTest {
 	    }
 	    if (bad != null) first = "layout " + r + ": " + bad;
 	}
-	// só reporta "poucos layouts utilizáveis" se nada mais específico já
-	// falhou - um defeito real interrompe o laço logo nos primeiros
-	// sorteios, e essa contagem baixa não pode apagar o índice e a causa
-	// que já foram encontrados
+	// only report "too few usable layouts" if nothing more specific has
+	// already failed - a real defect stops the loop within the first few
+	// draws, and that low count must not erase the index and the cause that
+	// were already found
 	if (first == null && drawn < runs / 2)
 	    first = "only " + drawn + " of " + runs + " layouts were usable";
 	check(name, null, first);
@@ -359,26 +361,25 @@ public class InventoryMovesTest {
 	sweep("19b sweep 4x3, 1 multi, packed", isz43, 1, 0, false, 9);
 	sweep("19c sweep 4x3, 1 multi, packed, vertical", isz43, 1, 0, true, 9);
 
-	// 20.x/21.x: as mesmas 2000 tiradas de antes, mas agora com células
-	// mascaradas - a única cobertura de máscara que passa por plan() em vez
-	// de cutucar Sim.drop() direto (ver simTests teste 4). A máscara é a
-	// mesma tanto em randomLayout (via used) quanto em plan/replay abaixo:
-	// nenhum dos dois vê uma grade mais livre do que a outra.
+	// 20.x/21.x: the same 2000 draws as before, but now with masked cells -
+	// the only mask coverage that goes through plan() instead of poking
+	// Sim.drop() directly (see simTests case 4). The mask is the same one in
+	// randomLayout (via used) and in plan/replay below: neither of them sees
+	// a freer grid than the other.
 	//
-	// O limite de itens fixados foi medido antes de virar asserção, do
-	// mesmo jeito que o limite sem máscara: instrumentando uma cópia
-	// descartável destas mesmas configurações por 2000 tiradas cada. Em
-	// todas elas o máximo observado foi exatamente nmulti (nunca mais),
-	// então o limite abaixo é o mesmo de sempre, só que agora verificado
-	// também com máscara em vez de só suposto.
+	// The pinned-item bound was measured before it became an assertion, the
+	// same way the unmasked bound was: by instrumenting a throwaway copy of
+	// these same configurations for 2000 draws each. In all of them the
+	// observed maximum was exactly nmulti (never more), so the bound below
+	// is the usual one, only now verified under a mask instead of assumed.
 	boolean[][] mask56 = grid(5, 6, 2,2, 4,0, 0,5, 1,3, 3,1, 4,5);
 	sweep("20a masked sweep 5x6, 2 multi, 3 free, horizontal",
 	      isz56, 2, 3, false, 55, mask56, 2);
 	sweep("20b masked sweep 5x6, 2 multi, 3 free, vertical",
 	      isz56, 2, 3, true, 55, mask56, 2);
-	// pacote quase até a última célula livre - o caso que mais aperta a
-	// interação entre assignTargets (que decide alvos vendo a máscara) e
-	// Sim (que recusa jogadas vendo a mesma máscara)
+	// packed to the last free cell - the case that squeezes hardest on the
+	// interaction between assignTargets (which picks targets seeing the
+	// mask) and Sim (which refuses moves seeing that same mask)
 	sweep("20c masked sweep 5x6, 2 multi, 0 free, horizontal",
 	      isz56, 2, 0, false, 55, mask56, 2);
 	sweep("20d masked sweep 5x6, 2 multi, 0 free, vertical",

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -108,8 +108,98 @@ public class InventoryMovesTest {
 	check("8 a drop covering two items is refused", Boolean.FALSE, s8.drop(new Coord(0, 0)));
     }
 
+    /**
+     * Replays a plan against a fresh simulator and returns the first thing that
+     * went wrong, or null. This is the whole contract in one place: no refusal,
+     * one take per item, cursor empty at the end, and every item exactly where
+     * the plan said - pinned items included, which have to be untouched rather
+     * than merely close.
+     */
+    private static String replay(boolean[][] mask, Coord isz, Coord[] slots, Coord[] current,
+				 InventoryMoves.Plan plan) {
+	InventoryMoves.Sim sim = new InventoryMoves.Sim(isz, mask, slots, current);
+	boolean[] taken = new boolean[slots.length];
+	for (InventoryMoves.Op op : plan.ops) {
+	    if (op.kind == InventoryMoves.TAKE) {
+		if (taken[op.item]) return "item " + op.item + " taken twice";
+		taken[op.item] = true;
+		// the widget reference the executor holds was captured before
+		// the sort started, and moving an item destroys and recreates
+		// its widget - so a take is only ever valid while the item is
+		// still on the cell it started from
+		if (!current[op.item].equals(sim.pos[op.item]))
+		    return "item " + op.item + " taken after it had already moved";
+		if (!sim.take(op.item)) return "take " + op.item + " refused";
+	    } else {
+		if (!sim.drop(op.cell)) return "drop at " + op.cell + " refused";
+	    }
+	}
+	if (sim.hand >= 0) return "cursor still holds item " + sim.hand;
+	for (int i = 0; i < slots.length; i++) {
+	    Coord want = (plan.targets[i] != null) ? plan.targets[i] : current[i];
+	    if (!want.equals(sim.pos[i]))
+		return "item " + i + " ended at " + sim.pos[i] + ", wanted " + want;
+	}
+	return null;
+    }
+
+    private static void planTests() {
+	Coord isz43 = new Coord(4, 3);
+
+	// 9: um armário 4x3 cheio até a última célula, com um 2x1 que precisa
+	// sair de (2,2). É o relato do usuário: hoje a evicção não encontra
+	// célula livre, avisa "inventory too full" e a fase 2 deixa o item
+	// grande na mão. O plano tem de sair sem uma única recusa.
+	Coord[] sl9 = coords(cat(rep(1, 2, 1), rep(10, 1, 1)));
+	Coord[] cur9 = coords(2,2,
+			      0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 3,1, 0,2, 1,2);
+	InventoryMoves.Plan p9 = InventoryMoves.plan(grid(4, 3), isz43, sl9, cur9, false);
+	check("9 full 4x3 with a 2x1 that has to move", null,
+	      replay(grid(4, 3), isz43, sl9, cur9, p9));
+
+	// 10: o mesmo armário com uma célula livre. Hoje esse caso falha em
+	// silêncio - nenhuma mensagem, e mesmo assim um item no cursor.
+	Coord[] sl10 = coords(cat(rep(1, 2, 1), rep(9, 1, 1)));
+	Coord[] cur10 = coords(2,2,
+			       0,0, 1,0, 2,0, 3,0, 0,1, 1,1, 2,1, 0,2, 1,2);
+	InventoryMoves.Plan p10 = InventoryMoves.plan(grid(4, 3), isz43, sl10, cur10, false);
+	check("10 same cupboard with one free cell", null,
+	      replay(grid(4, 3), isz43, sl10, cur10, p10));
+
+	// 11: doze 1x1 num 4x3 cheio, em ordem invertida. Puro ciclo: sem
+	// nenhuma célula livre, a única saída é a corrente de trocas.
+	Coord[] sl11 = coords(rep(12, 1, 1));
+	Coord[] cur11 = coords(3,2, 2,2, 1,2, 0,2, 3,1, 2,1, 1,1, 0,1, 3,0, 2,0, 1,0, 0,0);
+	InventoryMoves.Plan p11 = InventoryMoves.plan(grid(4, 3), isz43, sl11, cur11, false);
+	check("11 a full grid of 1x1 in reverse order", null,
+	      replay(grid(4, 3), isz43, sl11, cur11, p11));
+
+	// 12: dois itens grandes disputando lugar. Fora de escopo resolver o
+	// movimento em cadeia deles - mas o plano continua obrigado a ser
+	// executável, fixando o que não dá para mover.
+	Coord[] sl12 = coords(2,1, 2,1);
+	Coord[] cur12 = coords(2,0, 0,1);
+	InventoryMoves.Plan p12 = InventoryMoves.plan(grid(4, 3), isz43, sl12, cur12, false);
+	check("12 two multi-tile items contending for one spot", null,
+	      replay(grid(4, 3), isz43, sl12, cur12, p12));
+
+	// 13: nada a fazer produz plano vazio, não uma volta inútil
+	Coord[] sl13 = coords(rep(2, 1, 1));
+	Coord[] cur13 = coords(0,0, 1,0);
+	InventoryMoves.Plan p13 = InventoryMoves.plan(grid(4, 3), isz43, sl13, cur13, false);
+	check("13a an already sorted inventory plans no moves", 0, p13.ops.size());
+	check("13b and reports nothing pinned", Boolean.FALSE, p13.pinnedMulti);
+
+	// 14: modo vertical passa pelo mesmo contrato
+	InventoryMoves.Plan p14 = InventoryMoves.plan(grid(4, 3), isz43, sl9, cur9, true);
+	check("14 full 4x3 with a 2x1, vertical fill", null,
+	      replay(grid(4, 3), isz43, sl9, cur9, p14));
+    }
+
     public static void main(String[] args) {
 	simTests();
+	System.out.println();
+	planTests();
 	System.out.println();
 	System.out.println(failures == 0
 			   ? (total + " of " + total + " passed")

--- a/src/haven/automated/InventoryMovesTest.java
+++ b/src/haven/automated/InventoryMovesTest.java
@@ -143,6 +143,13 @@ public class InventoryMovesTest {
 	return null;
     }
 
+    /** How many items a plan left pinned - i.e. how many null entries in targets. */
+    private static int pinnedCount(Coord[] targets) {
+	int n = 0;
+	for (Coord t : targets) if (t == null) n++;
+	return n;
+    }
+
     private static void planTests() {
 	Coord isz43 = new Coord(4, 3);
 
@@ -194,6 +201,42 @@ public class InventoryMovesTest {
 	InventoryMoves.Plan p14 = InventoryMoves.plan(grid(4, 3), isz43, sl9, cur9, true);
 	check("14 full 4x3 with a 2x1, vertical fill", null,
 	      replay(grid(4, 3), isz43, sl9, cur9, p14));
+
+	// 15: um 2x1 cujo alvo cobre a própria célula atual - exatamente o caso
+	// em que single() via o próprio item como "ocupante" e nunca liberava a
+	// vaga. Ignorar quem está prestes a ser pego é o que permite o take;
+	// sem isso o item ficava fixado para sempre, mesmo sobrando espaço.
+	Coord[] sl15 = coords(2,1);
+	Coord[] cur15 = coords(1,0);
+	InventoryMoves.Plan p15 = InventoryMoves.plan(grid(4, 3), isz43, sl15, cur15, false);
+	check("15a a target overlapping the item's own current cell is still assigned",
+	      Boolean.TRUE, p15.targets[0] != null);
+	check("15b and the item actually leaves where it started", Boolean.TRUE,
+	      p15.targets[0] != null && !p15.targets[0].equals(cur15[0]));
+
+	// 16: uma grade 3x2 cheia com um 2x1 e quatro 1x1. A corrente que troca
+	// os 1x1 entre si esbarra, no meio do caminho, num alvo que o 2x1 ainda
+	// ocupa - ele só sai de lá mais tarde, quando (nunca, nesta grade sem
+	// folga) sobrar espaço para ele. Commitando a corrente sem testar antes,
+	// o código antigo culpava a vítima da troca pelo bloqueio e fixava o
+	// item errado; a grade inteira saía quase toda fixada. Adiando a
+	// corrente em vez disso, só o 2x1 - que de fato não cabe em lugar
+	// nenhum numa grade cheia - fica pra trás.
+	Coord isz32 = new Coord(3, 2);
+	Coord[] sl16 = coords(2,1, 1,1, 1,1, 1,1, 1,1);
+	Coord[] cur16 = coords(1,0, 0,1, 1,1, 2,1, 0,0);
+	InventoryMoves.Plan p16 = InventoryMoves.plan(grid(3, 2), isz32, sl16, cur16, false);
+	check("16a a chain blocked by an unmoved multi-tile item still sorts", null,
+	      replay(grid(3, 2), isz32, sl16, cur16, p16));
+	check("16b and only the multi-tile item ends up pinned", 1, pinnedCount(p16.targets));
+
+	// 17: a mesma grade cheia do teste 9, mas agora checando se ela
+	// realmente ordena - não só se executa sem recusa. É a asserção que
+	// teria pegado o defeito inteiro: antes das correções, plan() passava
+	// no replay já que fixar um item nunca é uma recusa, mas saía da
+	// função com quase a grade inteira fixada em vez de ordenada.
+	check("17 a packed grid with one multi-tile item pins at most it", Boolean.TRUE,
+	      pinnedCount(p9.targets) <= 1);
     }
 
     public static void main(String[] args) {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -98,6 +98,16 @@ public class InventorySorter implements Defer.Callable<Void> {
 	}
     }
 
+    /**
+     * Moves an entry to a new cell, keeping the occupancy grid in step. Clears the
+     * old rect before reassigning current, so callers cannot get the order wrong.
+     */
+    private static void relocate(Entry e, Coord to, boolean[][] occupied, Coord isz) {
+	InventoryLayout.markOccupied(occupied, isz, e.current, e.slots, false);
+	e.current = to;
+	InventoryLayout.markOccupied(occupied, isz, e.current, e.slots, true);
+    }
+
     private void doSort(Inventory inv) throws InterruptedException {
 	// Build mask grid (permanently blocked cells)
 	boolean[][] maskGrid = new boolean[inv.isz.x][inv.isz.y];
@@ -120,9 +130,9 @@ public class InventorySorter implements Defer.Callable<Void> {
 	}
 
 	// Live occupancy, kept in step with every move made below
-	boolean[][] occupied = new boolean[inv.isz.x][inv.isz.y];
+	boolean[][] occupiedGrid = new boolean[inv.isz.x][inv.isz.y];
 	for (Entry e : entries)
-	    InventoryLayout.markOccupied(occupied, inv.isz, e.current, e.slots, true);
+	    InventoryLayout.markOccupied(occupiedGrid, inv.isz, e.current, e.slots, true);
 
 	// Sort all items together
 	entries.sort(Comparator.comparing(e -> e.w, ITEM_COMPARATOR));
@@ -150,15 +160,13 @@ public class InventorySorter implements Defer.Callable<Void> {
 		    Coord cell = new Coord(tx, ty);
 		    for (Entry se : singles) {
 			if (se.current.equals(cell)) {
-			    Coord free = InventoryLayout.findFreeCell(inv.isz, maskGrid, occupied);
+			    Coord free = InventoryLayout.findFreeCell(inv.isz, maskGrid, occupiedGrid);
 			    if (free == null) { blocked = true; break; }
 			    se.w.item.wdgmsg("take", Coord.z);
 			    Thread.sleep(10);
 			    inv.wdgmsg("drop", free);
 			    Thread.sleep(10);
-			    InventoryLayout.markOccupied(occupied, inv.isz, se.current, se.slots, false);
-			    se.current = free;
-			    InventoryLayout.markOccupied(occupied, inv.isz, se.current, se.slots, true);
+			    relocate(se, free, occupiedGrid, inv.isz);
 			    break;
 			}
 		    }
@@ -169,9 +177,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    Thread.sleep(10);
 	    inv.wdgmsg("drop", me.target);
 	    Thread.sleep(10);
-	    InventoryLayout.markOccupied(occupied, inv.isz, me.current, me.slots, false);
-	    me.current = me.target;
-	    InventoryLayout.markOccupied(occupied, inv.isz, me.current, me.slots, true);
+	    relocate(me, me.target, occupiedGrid, inv.isz);
 	}
 	if (anyMultiSkipped)
 	    gui.error("Could not move all large items — inventory too full");

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -52,7 +52,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    return;
 	}
 	if (vertical)
-	    inv.ui.gui.msg("Sorting vertically", Color.WHITE);
+	    inv.ui.gui.msg("Sorting into columns", Color.WHITE);
 	start(new InventorySorter(Collections.singletonList(inv), inv.ui.gui, vertical));
     }
 

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -119,16 +119,21 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    entries.add(new Entry(w, slots, current));
 	}
 
+	// Live occupancy, kept in step with every move made below
+	boolean[][] occupied = new boolean[inv.isz.x][inv.isz.y];
+	for (Entry e : entries)
+	    InventoryLayout.markOccupied(occupied, inv.isz, e.current, e.slots, true);
+
 	// Sort all items together
 	entries.sort(Comparator.comparing(e -> e.w, ITEM_COMPARATOR));
 
 	// Assign target positions in scan order, respecting each item's size
-	boolean[][] assignGrid = copyGrid(maskGrid, inv.isz);
+	boolean[][] assignGrid = InventoryLayout.copyGrid(maskGrid, inv.isz);
 	for (Entry e : entries) {
-	    Coord pos = findFit(assignGrid, inv.isz, e.slots);
+	    Coord pos = InventoryLayout.findFit(assignGrid, inv.isz, e.slots, false);
 	    if (pos == null) break;
 	    e.target = pos;
-	    markGrid(assignGrid, pos, e.slots, true);
+	    InventoryLayout.markGrid(assignGrid, pos, e.slots, true);
 	}
 
 	List<Entry> singles = entries.stream().filter(e -> e.slots.x * e.slots.y == 1).collect(Collectors.toList());
@@ -145,13 +150,15 @@ public class InventorySorter implements Defer.Callable<Void> {
 		    Coord cell = new Coord(tx, ty);
 		    for (Entry se : singles) {
 			if (se.current.equals(cell)) {
-			    Coord free = findFreeCell(inv.isz, maskGrid, entries);
+			    Coord free = InventoryLayout.findFreeCell(inv.isz, maskGrid, occupied);
 			    if (free == null) { blocked = true; break; }
 			    se.w.item.wdgmsg("take", Coord.z);
 			    Thread.sleep(10);
 			    inv.wdgmsg("drop", free);
 			    Thread.sleep(10);
+			    InventoryLayout.markOccupied(occupied, inv.isz, se.current, se.slots, false);
 			    se.current = free;
+			    InventoryLayout.markOccupied(occupied, inv.isz, se.current, se.slots, true);
 			    break;
 			}
 		    }
@@ -162,7 +169,9 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    Thread.sleep(10);
 	    inv.wdgmsg("drop", me.target);
 	    Thread.sleep(10);
+	    InventoryLayout.markOccupied(occupied, inv.isz, me.current, me.slots, false);
 	    me.current = me.target;
+	    InventoryLayout.markOccupied(occupied, inv.isz, me.current, me.slots, true);
 	}
 	if (anyMultiSkipped)
 	    gui.error("Could not move all large items — inventory too full");
@@ -183,53 +192,6 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    }
 	    Thread.sleep(10);
 	}
-    }
-
-    // Find the first position where an item of given slots fits (left-to-right, top-to-bottom)
-    private static Coord findFit(boolean[][] grid, Coord isz, Coord slots) {
-	for (int y = 0; y <= isz.y - slots.y; y++) {
-	    for (int x = 0; x <= isz.x - slots.x; x++) {
-		if (fits(grid, x, y, slots)) return new Coord(x, y);
-	    }
-	}
-	return null;
-    }
-
-    private static boolean fits(boolean[][] grid, int ox, int oy, Coord slots) {
-	for (int x = 0; x < slots.x; x++)
-	    for (int y = 0; y < slots.y; y++)
-		if (grid[ox + x][oy + y]) return false;
-	return true;
-    }
-
-    // Find a free 1x1 cell not currently occupied by any item
-    private static Coord findFreeCell(Coord isz, boolean[][] maskGrid, List<Entry> entries) {
-	outer:
-	for (int y = 0; y < isz.y; y++) {
-	    for (int x = 0; x < isz.x; x++) {
-		if (maskGrid[x][y]) continue;
-		for (Entry e : entries) {
-		    for (int ex = e.current.x; ex < e.current.x + e.slots.x; ex++)
-			for (int ey = e.current.y; ey < e.current.y + e.slots.y; ey++)
-			    if (ex == x && ey == y) continue outer;
-		}
-		return new Coord(x, y);
-	    }
-	}
-	return null;
-    }
-
-    private static boolean[][] copyGrid(boolean[][] src, Coord sz) {
-	boolean[][] copy = new boolean[sz.x][sz.y];
-	for (int x = 0; x < sz.x; x++)
-	    copy[x] = Arrays.copyOf(src[x], sz.y);
-	return copy;
-    }
-
-    private static void markGrid(boolean[][] grid, Coord pos, Coord slots, boolean val) {
-	for (int x = 0; x < slots.x; x++)
-	    for (int y = 0; y < slots.y; y++)
-		grid[pos.x + x][pos.y + y] = val;
     }
 
     public static void cancel() {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -5,7 +5,6 @@ import haven.res.ui.tt.q.quality.Quality;
 
 import java.awt.Color;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static haven.Inventory.sqsz;
 
@@ -96,128 +95,70 @@ public class InventorySorter implements Defer.Callable<Void> {
     private static class Entry {
 	final WItem w;
 	final Coord slots;
-	Coord current;
-	Coord target;
+	final Coord current;
 
 	Entry(WItem w, Coord slots, Coord current) {
 	    this.w = w;
 	    this.slots = slots;
 	    this.current = current;
-	    this.target = current;
 	}
     }
 
-    /**
-     * Moves an entry to a new cell, keeping the occupancy grid in step. Clears the
-     * old rect before reassigning current, so callers cannot get the order wrong.
-     */
-    private static void relocate(Entry e, Coord to, boolean[][] occupied, Coord isz) {
-	InventoryLayout.markOccupied(occupied, isz, e.current, e.slots, false);
-	e.current = to;
-	InventoryLayout.markOccupied(occupied, isz, e.current, e.slots, true);
-    }
-
-    private boolean doSort(Inventory inv) throws InterruptedException {
-	// Build mask grid (permanently blocked cells)
-	boolean[][] maskGrid = new boolean[inv.isz.x][inv.isz.y];
+    /** The permanently blocked cells, as the server last described them. */
+    private static boolean[][] maskGrid(Inventory inv) {
+	boolean[][] mask = new boolean[inv.isz.x][inv.isz.y];
 	if (inv.sqmask != null) {
 	    int mo = 0;
 	    for (int y = 0; y < inv.isz.y; y++)
 		for (int x = 0; x < inv.isz.x; x++)
-		    maskGrid[x][y] = inv.sqmask[mo++];
+		    mask[x][y] = inv.sqmask[mo++];
 	}
+	return mask;
+    }
 
+    private boolean doSort(Inventory inv) throws InterruptedException {
 	// Collect all items, skip those with unloaded sprites
 	List<Entry> entries = new ArrayList<>();
 	for (Widget wdg = inv.lchild; wdg != null; wdg = wdg.prev) {
 	    if (!wdg.visible || !(wdg instanceof WItem)) continue;
 	    WItem w = (WItem) wdg;
 	    if (w.item.spr() == null) continue;
-	    Coord slots = w.sz.div(sqsz);
-	    Coord current = w.c.sub(1, 1).div(sqsz);
-	    entries.add(new Entry(w, slots, current));
+	    entries.add(new Entry(w, w.sz.div(sqsz), w.c.sub(1, 1).div(sqsz)));
 	}
-
-	// Live occupancy, kept in step with every move made below
-	boolean[][] occupiedGrid = new boolean[inv.isz.x][inv.isz.y];
-	for (Entry e : entries)
-	    InventoryLayout.markOccupied(occupiedGrid, inv.isz, e.current, e.slots, true);
-
-	// Sort all items together
 	entries.sort(Comparator.comparing(e -> e.w, ITEM_COMPARATOR));
 
-	// Assign target positions, largest item first so the big ones get their
-	// rects before first-fit can fragment the free space around them
 	Coord[] slots = new Coord[entries.size()];
 	Coord[] current = new Coord[entries.size()];
 	for (int i = 0; i < slots.length; i++) {
 	    slots[i] = entries.get(i).slots;
 	    current[i] = entries.get(i).current;
 	}
-	Coord[] targets = InventoryLayout.assignTargets(maskGrid, inv.isz, slots, current, vertical);
-	for (int i = 0; i < targets.length; i++) {
-	    if (targets[i] != null)
-		entries.get(i).target = targets[i];
-	}
 
-	List<Entry> singles = entries.stream().filter(e -> e.slots.x * e.slots.y == 1).collect(Collectors.toList());
-	List<Entry> multis  = entries.stream().filter(e -> e.slots.x * e.slots.y > 1).collect(Collectors.toList());
+	// The plan is validated against the server's own rules before a single
+	// message goes out, so nothing below can be refused. Messages are
+	// delivered in order, so no step waits for the one before it.
+	InventoryMoves.Plan plan =
+	    InventoryMoves.plan(maskGrid(inv), inv.isz, slots, current, vertical);
 
-	// Phase 1: place multi-tile items
-	// For each, first evict any 1x1 items from its target cells, then take+drop it
-	boolean anyMultiSkipped = false;
-	for (Entry me : multis) {
-	    if (me.current.equals(me.target)) continue;
-	    boolean blocked = false;
-	    for (int tx = me.target.x; tx < me.target.x + me.slots.x && !blocked; tx++) {
-		for (int ty = me.target.y; ty < me.target.y + me.slots.y && !blocked; ty++) {
-		    Coord cell = new Coord(tx, ty);
-		    for (Entry se : singles) {
-			if (se.current.equals(cell)) {
-			    Coord free = InventoryLayout.findFreeCell(inv.isz, maskGrid, occupiedGrid);
-			    if (free == null) { blocked = true; break; }
-			    se.w.item.wdgmsg("take", Coord.z);
-			    Thread.sleep(10);
-			    inv.wdgmsg("drop", free);
-			    Thread.sleep(10);
-			    relocate(se, free, occupiedGrid, inv.isz);
-			    break;
-			}
-		    }
-		}
+	for (InventoryMoves.Op op : plan.ops) {
+	    if (op.kind == InventoryMoves.TAKE) {
+		entries.get(op.item).w.item.wdgmsg("take", Coord.z);
+		// throttle only, not synchronisation: one pause per take is
+		// what the chain already cost, and half what a large item cost
+		Thread.sleep(10);
+	    } else {
+		inv.wdgmsg("drop", op.cell);
 	    }
-	    if (blocked) { anyMultiSkipped = true; continue; }
-	    me.w.item.wdgmsg("take", Coord.z);
-	    Thread.sleep(10);
-	    inv.wdgmsg("drop", me.target);
-	    Thread.sleep(10);
-	    relocate(me, me.target, occupiedGrid, inv.isz);
 	}
-	if (anyMultiSkipped)
-	    gui.error("Could not move all large items — inventory too full");
 
-	// Phase 2: sort 1x1 items using chain/swap algorithm
-	for (Entry se : singles) {
-	    if (se.current.equals(se.target)) continue;
-	    se.w.item.wdgmsg("take", Coord.z);
-	    Entry handu = se;
-	    // a legitimate cycle visits each single at most once, so n+1 is one spare
-	    int guard = singles.size() + 1;
-	    while (handu != null) {
-		if (--guard < 0) {
-		    gui.error("Sort incomplete — placement chain too long, check your cursor");
-		    return false;
-		}
-		inv.wdgmsg("drop", handu.target);
-		Entry next = null;
-		for (Entry x : singles) {
-		    if (x != handu && x.current.equals(handu.target)) { next = x; break; }
-		}
-		handu.current = handu.target;
-		handu = next;
-	    }
-	    Thread.sleep(10);
-	}
+	// A pinned large item is normal, not newsworthy: under the conservative
+	// swap policy a multi-tile item can only move into wholly empty space,
+	// so in a packed cupboard it stays put on nearly every sort, and there
+	// is nothing the player could do about it anyway. What is worth a toast
+	// is the sort achieving nothing at all - the one outcome that would
+	// otherwise look like silent failure.
+	if (plan.ops.isEmpty() && plan.pinnedMulti)
+	    gui.error("No room to move anything — inventory too tightly packed");
 	return true;
     }
 

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -81,15 +81,60 @@ public class InventorySorter implements Defer.Callable<Void> {
 
     @Override
     public Void call() throws InterruptedException {
+	Inventory last = null;
 	for (Inventory inv : inventories) {
 	    if (inv.parent == null) return null;
-	    if (!doSort(inv)) return null;
+	    // Between inventories, a non-blocking read: a cursor that is already
+	    // occupied is certain trouble, and sorting the next inventory on top
+	    // of it would scramble that one too. A null reading may just be lag,
+	    // which the settle below is for.
+	    if (gui.vhand != null) {
+		gui.error("Sort stopped early — item left on cursor");
+		return null;
+	    }
+	    doSort(inv);
+	    last = inv;
 	}
 	synchronized (lock) {
 	    if (current == this) current = null;
 	}
 	gui.ui.sfxrl(sfx_done);
+	if (last != null) settle(last);
 	return null;
+    }
+
+    /** How long to let the server catch up before reading the cursor. */
+    private static final int SETTLE_MS = 500;
+
+    /**
+     * Runs after the completion sound, so the wait costs no time the player
+     * sees - the items have already moved on screen by then. The plan is built
+     * so the server accepts every move, so this only ever fires when something
+     * outside the sort touched the inventory mid-run.
+     */
+    private void settle(Inventory inv) throws InterruptedException {
+	Thread.sleep(SETTLE_MS);
+	WItem held = gui.vhand;
+	if (held == null) return;
+	Coord free = freeRect(inv, held.sz.div(sqsz));
+	if (free != null) {
+	    inv.wdgmsg("drop", free);
+	    gui.error("Sort stopped early — item returned to inventory");
+	} else {
+	    gui.error("Sort stopped early — item left on cursor");
+	}
+    }
+
+    /** First rect of `slots` free in the inventory as it stands right now. */
+    private static Coord freeRect(Inventory inv, Coord slots) {
+	boolean[][] grid = maskGrid(inv);
+	for (Widget wdg = inv.lchild; wdg != null; wdg = wdg.prev) {
+	    if (!wdg.visible || !(wdg instanceof WItem)) continue;
+	    WItem w = (WItem) wdg;
+	    InventoryLayout.markOccupied(grid, inv.isz, w.c.sub(1, 1).div(sqsz),
+					 w.sz.div(sqsz), true);
+	}
+	return InventoryLayout.findFit(grid, inv.isz, slots, false);
     }
 
     private static class Entry {
@@ -116,7 +161,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	return mask;
     }
 
-    private boolean doSort(Inventory inv) throws InterruptedException {
+    private void doSort(Inventory inv) throws InterruptedException {
 	// Collect all items, skip those with unloaded sprites
 	List<Entry> entries = new ArrayList<>();
 	for (Widget wdg = inv.lchild; wdg != null; wdg = wdg.prev) {
@@ -159,7 +204,6 @@ public class InventorySorter implements Defer.Callable<Void> {
 	// otherwise look like silent failure.
 	if (plan.ops.isEmpty() && plan.pinnedMulti)
 	    gui.error("No room to move anything — inventory too tightly packed");
-	return true;
     }
 
     public static void cancel() {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -146,13 +146,18 @@ public class InventorySorter implements Defer.Callable<Void> {
 	// Sort all items together
 	entries.sort(Comparator.comparing(e -> e.w, ITEM_COMPARATOR));
 
-	// Assign target positions in scan order, respecting each item's size
-	boolean[][] assignGrid = InventoryLayout.copyGrid(maskGrid, inv.isz);
-	for (Entry e : entries) {
-	    Coord pos = InventoryLayout.findFit(assignGrid, inv.isz, e.slots, vertical);
-	    if (pos == null) break;
-	    e.target = pos;
-	    InventoryLayout.markGrid(assignGrid, pos, e.slots, true);
+	// Assign target positions, largest item first so the big ones get their
+	// rects before first-fit can fragment the free space around them
+	Coord[] slots = new Coord[entries.size()];
+	Coord[] current = new Coord[entries.size()];
+	for (int i = 0; i < slots.length; i++) {
+	    slots[i] = entries.get(i).slots;
+	    current[i] = entries.get(i).current;
+	}
+	Coord[] targets = InventoryLayout.assignTargets(maskGrid, inv.isz, slots, current, vertical);
+	for (int i = 0; i < targets.length; i++) {
+	    if (targets[i] != null)
+		entries.get(i).target = targets[i];
 	}
 
 	List<Entry> singles = entries.stream().filter(e -> e.slots.x * e.slots.y == 1).collect(Collectors.toList());

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -84,14 +84,15 @@ public class InventorySorter implements Defer.Callable<Void> {
 	Inventory last = null;
 	for (Inventory inv : inventories) {
 	    if (inv.parent == null) return null;
-	    // Between inventories, a non-blocking read: a cursor that is already
-	    // occupied is certain trouble, and sorting the next inventory on top
-	    // of it would scramble that one too. A null reading may just be lag,
-	    // which the settle below is for.
-	    if (gui.vhand != null) {
-		gui.error("Sort stopped early — item left on cursor");
-		return null;
-	    }
+	    // No cursor check here between inventories: widget messages are
+	    // reliable and ordered, so the server applies this inventory's first
+	    // take strictly after the previous inventory's last drop regardless
+	    // of what gui.vhand reads locally right now. What matters is the
+	    // cursor being empty server-side when each message is processed, and
+	    // ordering already guarantees that - a local read could only tell us
+	    // about echoes that have made it back, which is a different question.
+	    // A stray item left on the cursor at the very end is still caught by
+	    // settle below.
 	    doSort(inv);
 	    last = inv;
 	}
@@ -116,6 +117,17 @@ public class InventorySorter implements Defer.Callable<Void> {
 	Thread.sleep(SETTLE_MS);
 	WItem held = gui.vhand;
 	if (held == null) return;
+	// inv passed the same parent == null check in call()'s loop before it was
+	// sorted, but the wait above gives the window time to close too. A closed
+	// inv still has a populated child tree (Widget.remove() unlinks it from
+	// its parent but never clears its own children), so freeRect would
+	// happily compute a plausible-looking cell and the drop message would
+	// silently vanish - reporting "returned to inventory" would then be a
+	// lie, worse than the truth that it is still on the cursor.
+	if (inv.parent == null) {
+	    gui.error("Sort stopped early — item left on cursor");
+	    return;
+	}
 	Coord free = freeRect(inv, held.sz.div(sqsz));
 	if (free != null) {
 	    inv.wdgmsg("drop", free);

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -128,7 +128,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    gui.error("Sort stopped early — item left on cursor");
 	    return;
 	}
-	Coord free = freeRect(inv, held.sz.div(sqsz));
+	Coord free = freeRect(inv, held.sz.div(sqsz), vertical);
 	if (free != null) {
 	    inv.wdgmsg("drop", free);
 	    gui.error("Sort stopped early — item returned to inventory");
@@ -137,8 +137,13 @@ public class InventorySorter implements Defer.Callable<Void> {
 	}
     }
 
-    /** First rect of `slots` free in the inventory as it stands right now. */
-    private static Coord freeRect(Inventory inv, Coord slots) {
+    /**
+     * First rect of `slots` free in the inventory as it stands right now.
+     * `vertical` only matters for which free rect is found first, not whether
+     * one is found - but it might as well agree with the sort that just ran
+     * rather than always scanning rows first.
+     */
+    private static Coord freeRect(Inventory inv, Coord slots, boolean vertical) {
 	boolean[][] grid = maskGrid(inv);
 	for (Widget wdg = inv.lchild; wdg != null; wdg = wdg.prev) {
 	    if (!wdg.visible || !(wdg instanceof WItem)) continue;
@@ -146,7 +151,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    InventoryLayout.markOccupied(grid, inv.isz, w.c.sub(1, 1).div(sqsz),
 					 w.sz.div(sqsz), true);
 	}
-	return InventoryLayout.findFit(grid, inv.isz, slots, false);
+	return InventoryLayout.findFit(grid, inv.isz, slots, vertical);
     }
 
     private static class Entry {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -187,7 +187,12 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    if (se.current.equals(se.target)) continue;
 	    se.w.item.wdgmsg("take", Coord.z);
 	    Entry handu = se;
+	    int guard = singles.size() + 1;
 	    while (handu != null) {
+		if (--guard < 0) {
+		    gui.error("Sort incomplete: placement chain too long — check your cursor");
+		    return;
+		}
 		inv.wdgmsg("drop", handu.target);
 		Entry next = null;
 		for (Entry x : singles) {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -75,7 +75,7 @@ public class InventorySorter implements Defer.Callable<Void> {
     public Void call() throws InterruptedException {
 	for (Inventory inv : inventories) {
 	    if (inv.parent == null) return null;
-	    doSort(inv);
+	    if (!doSort(inv)) return null;
 	}
 	synchronized (lock) {
 	    if (current == this) current = null;
@@ -108,7 +108,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	InventoryLayout.markOccupied(occupied, isz, e.current, e.slots, true);
     }
 
-    private void doSort(Inventory inv) throws InterruptedException {
+    private boolean doSort(Inventory inv) throws InterruptedException {
 	// Build mask grid (permanently blocked cells)
 	boolean[][] maskGrid = new boolean[inv.isz.x][inv.isz.y];
 	if (inv.sqmask != null) {
@@ -187,11 +187,12 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    if (se.current.equals(se.target)) continue;
 	    se.w.item.wdgmsg("take", Coord.z);
 	    Entry handu = se;
+	    // a legitimate cycle visits each single at most once, so n+1 is one spare
 	    int guard = singles.size() + 1;
 	    while (handu != null) {
 		if (--guard < 0) {
-		    gui.error("Sort incomplete: placement chain too long — check your cursor");
-		    return;
+		    gui.error("Sort incomplete — placement chain too long, check your cursor");
+		    return false;
 		}
 		inv.wdgmsg("drop", handu.target);
 		Entry next = null;
@@ -203,6 +204,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    }
 	    Thread.sleep(10);
 	}
+	return true;
     }
 
     public static void cancel() {

--- a/src/haven/automated/InventorySorter.java
+++ b/src/haven/automated/InventorySorter.java
@@ -3,6 +3,7 @@ package haven.automated;
 import haven.*;
 import haven.res.ui.tt.q.quality.Quality;
 
+import java.awt.Color;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,18 +34,26 @@ public class InventorySorter implements Defer.Callable<Void> {
     private Defer.Future<Void> task;
     private final List<Inventory> inventories;
     private final GameUI gui;
+    private final boolean vertical;
 
-    private InventorySorter(List<Inventory> inventories, GameUI gui) {
+    private InventorySorter(List<Inventory> inventories, GameUI gui, boolean vertical) {
 	this.inventories = inventories;
 	this.gui = gui;
+	this.vertical = vertical;
     }
 
     public static void sort(Inventory inv) {
+	sort(inv, false);
+    }
+
+    public static void sort(Inventory inv, boolean vertical) {
 	if (inv.ui.gui.vhand != null) {
 	    inv.ui.gui.error("Need empty cursor to sort inventory!");
 	    return;
 	}
-	start(new InventorySorter(Collections.singletonList(inv), inv.ui.gui));
+	if (vertical)
+	    inv.ui.gui.msg("Sorting vertically", Color.WHITE);
+	start(new InventorySorter(Collections.singletonList(inv), inv.ui.gui, vertical));
     }
 
     public static void sortAll(GameUI gui) {
@@ -59,7 +68,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	    targets.add(inv);
 	}
 	if (!targets.isEmpty()) {
-	    start(new InventorySorter(targets, gui));
+	    start(new InventorySorter(targets, gui, false));
 	}
     }
 
@@ -140,7 +149,7 @@ public class InventorySorter implements Defer.Callable<Void> {
 	// Assign target positions in scan order, respecting each item's size
 	boolean[][] assignGrid = InventoryLayout.copyGrid(maskGrid, inv.isz);
 	for (Entry e : entries) {
-	    Coord pos = InventoryLayout.findFit(assignGrid, inv.isz, e.slots, false);
+	    Coord pos = InventoryLayout.findFit(assignGrid, inv.isz, e.slots, vertical);
 	    if (pos == null) break;
 	    e.target = pos;
 	    InventoryLayout.markGrid(assignGrid, pos, e.slots, true);


### PR DESCRIPTION
The sort button can leave an item stuck on the cursor, and reports
`Could not move all large items — inventory too full` on inventories that are
provably not too full. This reworks the sorter so the whole move sequence is
built and verified before a single message goes out, and adds an opt-in
column-fill mode on the same button.

Branch is on top of `master` @ `d7b93ccd4` (v1.68), no rebase needed.

## The bug

Sorting a well-filled cupboard leaves a multi-tile item on the cursor and the
rest of the sort silently goes wrong — sometimes with the "too full" toast,
sometimes with no message at all. There are four independent causes.

1. **`findFreeCell` gave up on a row too early.** The `continue` targeted the
   outer loop, so hitting an occupied cell skipped every remaining cell in that
   row. It could only ever return a cell from a row's leading free prefix, and
   returned `null` whenever every row had its first cell taken. Phase 1 read
   that `null` as "inventory full" and skipped the item.

2. **Targets were assigned first-fit in display order** (name, resource,
   quality), with item size playing no part. The 1x1s are the majority and
   usually sort earlier alphabetically, so they scattered across the grid first
   and split the free space into pieces too small for the multi-tile item that
   came later. The pre-sort layout is a witness that a feasible packing exists;
   first-fit by name is not guaranteed to find one.

3. **The assignment loop `break`ed on the first misfit**, leaving every later
   entry with `target == current`. Those inherited targets never entered the
   occupancy grid, so an assigned target could land on cells an unplaced item
   still occupied. The sorter then dropped onto an occupied cell, the server
   refused it because the occupant was multi-tile, and the item stayed on the
   cursor — desyncing every take/drop after it.

4. **Phase 2's chain-swap loop was unbounded.** An entry with
   `target == current` that was never marked in the assign grid lets a target
   collide with another item's current cell, and the chain then cycles forever
   with no sleep inside it, flooding the server.

And when the phase-2 guard did trip, the bare `return` unwound only `doSort`,
so `call()` still played the success chime and moved on to the next inventory
with an item on the cursor — a state every entry point refuses to start from.

## The fix

Rather than patching each of those in place, deciding is separated from doing.

- **`InventoryLayout`** (new) — pure grid placement: *where* each item should
  end up. Packs largest-area first, ties broken along the fill direction, then
  display order, so the big rects are reserved while the grid is still whole.
  An item that fits nowhere is pinned where it already is (its rect reserved,
  the pass restarted) instead of aborting the rest of the list. That
  terminates: each restart pins one more item, and the all-pinned state is the
  original layout, which fits by construction.

- **`InventoryMoves`** (new) — decides *in what order* to move, against a model
  of the server's own take and drop rules. Every candidate move is checked
  against that model before it is emitted, so a refusal is impossible rather
  than merely unlikely. Widget messages are reliable and ordered
  (`Connection.java:340,795` outbound, `494-505` inbound), so the client never
  has to wait for a reply — it only has to send a sequence the server will
  accept.

- **`InventorySorter`** — now an executor with no model of its own: read the
  inventory, ask for a layout and a plan, translate each entry into a message.

The planner prefers direct moves, which removes the old eviction step entirely:
an item moved onto its own target is never in the way again, whereas the old
code shoved items into whatever cell was free — including cells inside the very
rect it was trying to clear. Where no direct move is available it falls back to
the swap chain the sorter already relied on, but only 1x1 onto 1x1. Any swap
involving a multi-tile item is refused: whether the server performs it has
never been exercised, and guessing wrong is exactly what leaves a large item on
the cursor.

An item can fit its target and still be impossible to carry there — a large
item whose destination is held by another large item. That item is pinned and
the layout recomputed around it, the same pin-and-restart loop one level up,
bounded by the item count.

Behavioural notes:

- `Thread.sleep(10)` stays, one per take, as throttling only — nothing waits on
  it for correctness. That is what the chain already cost and half of what a
  large item cost, so a sort is no slower than before.
- The "too full" toast now only fires when the sort achieves *nothing at all*.
  A pinned large item is normal, not newsworthy: under the conservative swap
  policy a multi-tile item can only move into wholly empty space, so in a
  packed cupboard it stays put on most sorts and there is nothing the player
  could do about it.
- The cursor is checked once, after the completion sound, so the wait costs no
  time the player sees. If something outside the sort touched the inventory
  mid-run, the held item is put back and the player is told. If the window has
  since closed, the player is told the item is still on the cursor rather than
  being told it was returned — a closed `Inventory` keeps its child tree, so
  the drop message would silently vanish and the reassuring message would be a
  lie.

## The new feature: column fill

**Shift+click the sort button** fills columns instead of rows; plain click is
unchanged. Tooltip is now `Sort (Shift+Click: fill columns)`.

Row-major packing scatters a run of like items across rows, which reads badly
in tall containers and for anyone who scans their inventory by column. The fill
direction is threaded all the way through — `findFit`, the pack order's
tie-break, the planner, and the fallback drop — so a vertical sort is
column-major everywhere rather than only at the first scan.

`sort(Inventory)` delegates to `sort(Inventory, boolean)`, so existing callers
(including `sortAll`) are untouched and keep the old behaviour. The flag is read
on the UI thread and passed by value; the `Defer` worker never touches `ui`.

### Example

https://github.com/user-attachments/assets/75594bef-b6b9-4623-abb2-5214233f8b9b

## Visible trade-off

Items now group by size, and within a size by name, so a large item can sit
ahead of alphabetically earlier small ones. That already happened
inconsistently whenever a multi-tile item jumped to the first rect that fit;
this makes the rule uniform, and it is what buys the guarantee that an item set
which fitted before the sort still fits after it.

## Testing

`lib/` has no test jar and `build.xml` has no test target, so both new classes
ship with a self-checking `main()` — the same shape as `haven/test/BaseTest`,
`haven/render/jogl/Test` and the other `main()`-bearing classes already under
`src`. Exit code is non-zero on failure.

```
javac -d build/classes -cp build/classes src/haven/automated/InventoryLayout*.java
java -cp build/classes haven.automated.InventoryLayoutTest      # 38 checks
javac -d build/classes -cp build/classes src/haven/automated/InventoryMoves*.java
java -cp build/classes haven.automated.InventoryMovesTest       # 42 checks
```

`InventoryLayoutTest` covers the placement rules, both fill directions, masked
cells, and the pin-and-restart path. `InventoryMovesTest` covers the modelled
server rules, a fixed regression case per bug above, and a randomised sweep of
2000 layouts per configuration — masked and unmasked, both fill directions —
that replays every plan against the model and asserts two things: that no move
is refused, and that the plan actually *sorts*, pinning at most the multi-tile
items. The second assertion is the one that matters; an earlier version of the
planner passed replay on every trial simply because a plan that moves nothing
is never refused.

Performance of the placement pass was measured at 0.7 ms worst case on a 10x10
grid with 95 items, against the ~1900 ms of throttling the sort already spends
moving them. The common path is a single pass, 0.007 ms.

## Note

`build.xml` compiles all of `src`, so the two test classes end up in the jar.
They are small, have no static initialisers and are never referenced at
runtime, but say the word and I will move them out or drop them.