### PR TITLE
Send marker ids as strings rather than malformed long

### DIFF
--- a/src/haven/automated/mapper/MappingClient.java
+++ b/src/haven/automated/mapper/MappingClient.java
@@ -475,7 +475,7 @@ public class MappingClient {
 			obj.put("x", offset.x);
 			obj.put("y", offset.y);
 			obj.put("type", "shared");
-			obj.put("id", marker.oid);
+			obj.put("id", marker.oid.toString());
 			obj.put("image", marker.res.name);
 
 			scheduler.execute(new MarkerUpdate(new JSONArray(List.of(obj))));


### PR DESCRIPTION
It's a breaking change, I know, but the alternative is much more invasive. A few months ago, after one of Loftar's changes, the IDs were no longer serialized into a proper JSON number. The culprit is the `UID` class that extends the `Number`.

Here's the payload I encountered:
```
[{"image":"gfx/terobjs/mm/geyser","name":"Geyser","x":21,"y":30,"gridID":"-3325592917485398562","id":67250f7900000e46,"type":"shared"}]
```

Take a look at the id part, it's 67250f7900000e46, without quote marks, which is not a proper JSON number, and it won't be properly parsed. Casting it to string fixes the problem, at the cost of a breaking API change. The alternative is to turn it back into a number somehow, but I didn't bother doing so, strings are just more Loftar-proof.