### PR TITLE
Prospecting: mark the find on the map

### DIFF
--- a/src/haven/ProspectingText.java
+++ b/src/haven/ProspectingText.java
@@ -1,0 +1,40 @@
+package haven;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/* Text handling for the server's Prospecting window, kept out of the widget so
+ * it can be checked without loading any UI class - Window's static initialisers
+ * fetch textures, which no headless test can do. */
+public class ProspectingText {
+    /* The only prospecting result whose position we can trust: the deposit is
+     * under the player's feet. The directional variants say nothing about where
+     * the player stands, so they deliberately do not match. */
+    private static final Pattern DETECT =
+	Pattern.compile("There appears to be (.*) directly below\\.");
+
+    /* Returns the substance named in a prospecting label, or null if the label
+     * is not a direct find. */
+    public static String detect(String text) {
+	if(text == null)
+	    return(null);
+	Matcher m = DETECT.matcher(text.trim());
+	if(!m.matches())
+	    return(null);
+	String substance = m.group(1).trim();
+	return(substance.isEmpty() ? null : substance);
+    }
+
+    /* "black coal" -> "Black Coal (below)" */
+    public static String markerName(String substance) {
+	StringBuilder buf = new StringBuilder();
+	for(String word : substance.split(" ")) {
+	    if(word.isEmpty())
+		continue;
+	    if(buf.length() > 0)
+		buf.append(' ');
+	    buf.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+	}
+	return(buf.toString() + " (below)");
+    }
+}

--- a/src/haven/ProspectingTextTest.java
+++ b/src/haven/ProspectingTextTest.java
@@ -1,0 +1,67 @@
+package haven;
+
+/**
+ * Self-checking tests for ProspectingText. No JUnit: lib/ has no test jar and
+ * build.xml has no test target.
+ *
+ * Run: make check
+ */
+public class ProspectingTextTest {
+    private static int total = 0;
+    private static int failures = 0;
+
+    private static void check(String name, Object expected, Object actual) {
+	total++;
+	boolean ok = (expected == null) ? (actual == null) : expected.equals(actual);
+	if (!ok) failures++;
+	System.out.printf("%-58s %s%n", name,
+			  ok ? "PASS" : "FAIL (expected " + expected + ", got " + actual + ")");
+    }
+
+    private static void detectTests() {
+	check("detect: single-word substance",
+	      "microlite",
+	      ProspectingText.detect("There appears to be microlite directly below."));
+	check("detect: multi-word substance",
+	      "black coal",
+	      ProspectingText.detect("There appears to be black coal directly below."));
+	check("detect: surrounding whitespace is ignored",
+	      "cassiterite",
+	      ProspectingText.detect("  There appears to be cassiterite directly below.  "));
+	check("detect: directional variant is not a find",
+	      null,
+	      ProspectingText.detect("There appears to be cassiterite somewhere to the north."));
+	check("detect: unrelated label",
+	      null,
+	      ProspectingText.detect("Nothing of interest here."));
+	check("detect: blank substance",
+	      null,
+	      ProspectingText.detect("There appears to be  directly below."));
+	check("detect: null label",
+	      null,
+	      ProspectingText.detect(null));
+    }
+
+    private static void markerNameTests() {
+	check("markerName: capitalises a single word",
+	      "Microlite (below)",
+	      ProspectingText.markerName("microlite"));
+	check("markerName: capitalises every word",
+	      "Black Coal (below)",
+	      ProspectingText.markerName("black coal"));
+	check("markerName: leaves an already-capitalised word alone",
+	      "Cassiterite (below)",
+	      ProspectingText.markerName("Cassiterite"));
+    }
+
+    public static void main(String[] args) {
+	detectTests();
+	System.out.println();
+	markerNameTests();
+	System.out.println();
+	System.out.println(failures == 0
+			   ? (total + " of " + total + " passed")
+			   : (failures + " of " + total + " failed"));
+	System.exit(failures == 0 ? 0 : 1);
+    }
+}

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -87,8 +87,12 @@ public class ProspectingWnd extends Window {
 	MapFile file = mapfile.file;
 	Coord tc = loc.tc.add(pc.floor(tilesz));
 	String name = ProspectingText.markerName(detected);
+	/* onmap = false: no flag planted in the world. Prospecting is done in
+	 * bulk, and a flag per find would litter the ground. The marker is
+	 * still on the minimap and in the list, and "Display in world" turns
+	 * the flag on for the ones worth seeing from afar. */
 	file.add(new PMarker(file, loc.seg.id, tc, name,
-			     BuddyWnd.gc[new Random().nextInt(BuddyWnd.gc.length)], true));
+			     BuddyWnd.gc[new Random().nextInt(BuddyWnd.gc.length)], false));
 	/* The failures above all speak, so the success says its piece too -
 	 * and it names the marker, which is how you find it on the map. */
 	gui.msg("Marked: " + name, Color.WHITE);

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -1,0 +1,89 @@
+package haven;
+
+import java.util.Random;
+
+import haven.MapFile.PMarker;
+
+import static haven.MCache.tilesz;
+
+/* The server's prospecting result window, with a Mark button added next to its
+ * Dismiss button. The server builds the window in pieces - caption first, then
+ * the label and the button, then a pack - so the button starts hidden and only
+ * appears once a label proves the find is directly below us. */
+public class ProspectingWnd extends Window {
+    private final Button mark;
+    private String detected = null;
+    private Coord2d pc = null;
+
+    public ProspectingWnd(Coord sz, String cap, boolean lg) {
+	super(sz, cap, lg);
+	mark = add(new Button(UI.scale(100), "Mark", false), UI.scale(105, 25));
+	mark.action(this::mark);
+	mark.hide();
+    }
+
+    protected void attach(UI ui) {
+	super.attach(ui);
+	/* Where we stood when the result came in - the player can walk off
+	 * before clicking, and then the current position is not the find. */
+	pc = playerc();
+    }
+
+    public <T extends Widget> T add(T child) {
+	super.add(child);
+	/* The constructor's own add() runs before mark is assigned. */
+	if((mark != null) && (child instanceof Label)) {
+	    String substance = ProspectingText.detect(((Label)child).texts);
+	    if(substance != null) {
+		detected = substance;
+		mark.show();
+	    }
+	}
+	return(child);
+    }
+
+    public void pack() {
+	if(mark != null) {
+	    for(Button btn : children(Button.class)) {
+		if(btn != mark) {
+		    mark.c = Coord.of(mark.c.x, btn.c.y);
+		    break;
+		}
+	    }
+	}
+	super.pack();
+    }
+
+    private Coord2d playerc() {
+	if((ui == null) || (ui.gui == null) || (ui.gui.map == null))
+	    return(null);
+	Gob player = ui.gui.map.player();
+	return((player == null) ? null : player.rc);
+    }
+
+    private void mark() {
+	if(detected == null)
+	    return;
+	GameUI gui = (ui == null) ? null : ui.gui;
+	if(gui == null)
+	    return;
+	if(pc == null)
+	    pc = playerc();
+	if(pc == null) {
+	    gui.error("Prospecting: cannot tell where you are.");
+	    return;
+	}
+	MapWnd mapfile = gui.mapfile;
+	MiniMap.Location loc = (mapfile == null) ? null : mapfile.view.sessloc;
+	if(loc == null) {
+	    gui.error("Prospecting: the map is not loaded yet.");
+	    return;
+	}
+	MapFile file = mapfile.file;
+	Coord tc = loc.tc.add(pc.floor(tilesz));
+	file.add(new PMarker(file, loc.seg.id, tc, ProspectingText.markerName(detected),
+			     BuddyWnd.gc[new Random().nextInt(BuddyWnd.gc.length)], true));
+	/* One find, one marker. */
+	mark.hide();
+    }
+}

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -1,5 +1,6 @@
 package haven;
 
+import java.awt.Color;
 import java.util.Random;
 
 import haven.MapFile.PMarker;
@@ -85,8 +86,12 @@ public class ProspectingWnd extends Window {
 	}
 	MapFile file = mapfile.file;
 	Coord tc = loc.tc.add(pc.floor(tilesz));
-	file.add(new PMarker(file, loc.seg.id, tc, ProspectingText.markerName(detected),
+	String name = ProspectingText.markerName(detected);
+	file.add(new PMarker(file, loc.seg.id, tc, name,
 			     BuddyWnd.gc[new Random().nextInt(BuddyWnd.gc.length)], true));
+	/* The failures above all speak, so the success says its piece too -
+	 * and it names the marker, which is how you find it on the map. */
+	gui.msg("Marked: " + name, Color.WHITE);
 	/* One find, one marker. Greyed out rather than hidden: a disabled
 	 * button ignores clicks all the same, and hiding it would leave the
 	 * hole its own width carved into the window. */

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -87,7 +87,9 @@ public class ProspectingWnd extends Window {
 	Coord tc = loc.tc.add(pc.floor(tilesz));
 	file.add(new PMarker(file, loc.seg.id, tc, ProspectingText.markerName(detected),
 			     BuddyWnd.gc[new Random().nextInt(BuddyWnd.gc.length)], true));
-	/* One find, one marker. */
-	mark.hide();
+	/* One find, one marker. Greyed out rather than hidden: a disabled
+	 * button ignores clicks all the same, and hiding it would leave the
+	 * hole its own width carved into the window. */
+	mark.disable(true);
     }
 }

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -12,6 +12,7 @@ import static haven.MCache.tilesz;
  * the label and the button, then a pack - so the button starts hidden and only
  * appears once a label proves the find is directly below us. */
 public class ProspectingWnd extends Window {
+    private static final int GAP = UI.scale(5);
     private final Button mark;
     private String detected = null;
     private Coord2d pc = null;
@@ -47,16 +48,33 @@ public class ProspectingWnd extends Window {
 	if(mark != null) {
 	    for(Button btn : children(Button.class)) {
 		if(btn != mark) {
-		    /* A large button's box is taller than the frame it draws,
-		     * which sits centred in it - so matching box tops would
-		     * leave ours riding high. Centre the boxes instead and the
-		     * frames line up whichever size the server's button is. */
-		    mark.c = Coord.of(mark.c.x, btn.c.y + ((btn.sz.y - mark.sz.y) / 2));
+		    layout(btn);
 		    break;
 		}
 	    }
 	}
 	super.pack();
+    }
+
+    /* The server lays the window out for its one button and then packs it to
+     * the text, so a long line leaves the button sitting off to the left -
+     * with or without ours beside it. Centre the whole row under the text. */
+    private void layout(Button dismiss) {
+	int width = 0;
+	for(Widget wdg = child; wdg != null; wdg = wdg.next) {
+	    if((wdg == deco) || !wdg.visible || (wdg instanceof Button))
+		continue;
+	    width = Math.max(width, wdg.c.x + wdg.sz.x);
+	}
+	int roww = dismiss.sz.x + (mark.visible ? (GAP + mark.sz.x) : 0);
+	int x = Math.max(0, (width - roww) / 2);
+	dismiss.c = Coord.of(x, dismiss.c.y);
+	/* A large button's box is taller than the frame it draws, which sits
+	 * centred in it - so matching box tops would leave ours riding high.
+	 * Centre the boxes instead and the frames line up whichever size the
+	 * server's button is. */
+	mark.c = Coord.of(x + dismiss.sz.x + GAP,
+			  dismiss.c.y + ((dismiss.sz.y - mark.sz.y) / 2));
     }
 
     private Coord2d playerc() {

--- a/src/haven/ProspectingWnd.java
+++ b/src/haven/ProspectingWnd.java
@@ -46,7 +46,11 @@ public class ProspectingWnd extends Window {
 	if(mark != null) {
 	    for(Button btn : children(Button.class)) {
 		if(btn != mark) {
-		    mark.c = Coord.of(mark.c.x, btn.c.y);
+		    /* A large button's box is taller than the frame it draws,
+		     * which sits centred in it - so matching box tops would
+		     * leave ours riding high. Centre the boxes instead and the
+		     * frames line up whichever size the server's button is. */
+		    mark.c = Coord.of(mark.c.x, btn.c.y + ((btn.sz.y - mark.sz.y) / 2));
 		    break;
 		}
 	    }

--- a/src/haven/Window.java
+++ b/src/haven/Window.java
@@ -113,6 +113,8 @@ public class Window extends Widget {
 	    Coord sz = UI.scale((Coord)args[0]);
 	    String cap = (args.length > 1) ? (String)args[1] : null;
 	    boolean lg = (args.length > 2) ? Utils.bv(args[2]) : false;
+	    if("Prospecting".equals(cap))
+		return(new ProspectingWnd(sz, cap, lg));
 	    return(new Window(sz, cap, lg));
 	}
     }


### PR DESCRIPTION
## What this does

When prospecting turns something up directly below you, the server opens a
`Prospecting` window with the text and a single `Dismiss` button. There is no
way to record the find: you dismiss the window and the position is gone, or you
open the map and create a marker by hand, typing the substance yourself.

This adds a `Mark` button next to `Dismiss`. Clicking it creates a map marker
named `<Substance> (below)` — `Microlite (below)`, `Greenschist (below)` — with
a random colour from the same palette the map's own mark button uses, at the
position you were standing when the window opened, not where you are when you
click.

<img width="397" height="199" alt="screenshot-2026-08-12_14-53-17" src="https://github.com/user-attachments/assets/f14bb49f-f853-4ebc-9419-f3e70508ade9" />


## Details

- The button only appears for the `There appears to be X directly below.`
  result. The directional and distance variants say a vein is *somewhere over
  there*, so your own position would be the wrong thing to mark; there the
  window looks exactly as it does today.
- The marker is created without a flag planted in the world (`onmap = false`).
  Prospecting is done in bulk and a flag per find would litter the ground. It is
  still on the minimap and in the marker list, and `Display in world` turns the
  flag on for the ones worth seeing from afar.
- Marking reports `Marked: <name>` in the system log — both failure paths
  already spoke, so the success does too, and the name is how you find it on the
  map. The window stays open; `Dismiss` still closes it.
- After marking, the button is greyed out rather than hidden: one find, one
  marker. A disabled button ignores clicks all the same, and hiding it would
  carve a hole its own width into the packed window.
- The button row is centred under the text. The server positions its button for
  its own layout and then packs the window down to the label, so a long line
  left the button sitting off to the left — visible in the vanilla client too,
  on `No minerals found directly below.`

## Implementation

`Window`'s `@RName("wnd")` factory routes the `Prospecting` caption to
`ProspectingWnd` — two lines, the only change to an existing file. Everything
else lives in the new class.

The server builds the window in pieces: the caption first, then the label and
the button, then a `pack`. So the `Mark` button is created hidden and only shows
once a label proves the find is directly below; `attach` captures the player's
position before the label even arrives; `pack` places the row and lets the
window resize around it.

Text handling — the regex and the marker name — sits apart in
`ProspectingText`, two pure static methods. `Window`'s static initialisers load
textures, which no headless test can do, so keeping the text out of the widget
is what makes it testable at all.

## Testing

`ProspectingTextTest` (self-checking `main()`, same style as the existing tests
in the repo): 10 checks over `detect` and `markerName` — the directional variant
and unrelated labels return null, whitespace and multi-word substances are
handled, capitalisation is per word.

In game: found ore directly below and marked it, checked the marker's name and
position in the map list, walked a screen away before clicking and confirmed the
marker landed where the find was, confirmed a no-find window shows only a
centred `Dismiss`, and confirmed the marker survives a client restart.